### PR TITLE
Action queue

### DIFF
--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -58,18 +58,31 @@ class Engine:
         for entity in self.guild.roster:
             print(entity.get_dict())
 
+    def dying(self, target):
+
+        if target in eng.guild.team.members:
+            results = [{"message": f"{target.name.first_name} is dead!"}]
+        else:
+            results = [{"message": f"{target.name.first_name} is dead!"}]
+
+        return results
+
     def process_action_queue(self):
         new_action_queue = []
+        self._check_action_queue()
         for action in self.action_queue:
             if "message" in action:
                 print(action["message"])
                 self.messages.append(action["message"])
-                time.sleep(0.75)
+
+            if "dying" in action:
+                target = action["dying"]
+                self.dying(target)
         
         self.action_queue = new_action_queue
 
 
-    def check_action_queue(self):
+    def _check_action_queue(self):
         for item in self.action_queue:
             print(item)
 
@@ -105,6 +118,9 @@ def scripted_run():
                     
                     eng.action_queue.extend(merc.fighter.attack(eng.dungeon.enemies[0]))
 
+                    if eng.dungeon.enemies[0].is_dead:
+                        eng.action_queue.extend(eng.dying(eng.dungeon.enemies[0]))
+
                     if merc.fighter.retreating == True:
                         eng.guild.team.move_to_roster(i)
 
@@ -119,8 +135,12 @@ def scripted_run():
                             }
                         )
                         eng.guild.team.move_to_roster(i)
+                    
+                    if eng.dungeon.boss.is_dead:
+                        eng.action_queue.extend(eng.dying(eng.dungeon.boss))
 
             if merc.is_dead:
+                eng.action_queue.extend(eng.dying(merc))
                 eng.guild.team.move_to_roster(i)
                 eng.guild.remove_from_roster(i)
 

--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -61,9 +61,16 @@ class Engine:
     def dying(self, target):
 
         if target in eng.guild.team.members:
-            results = [{"message": f"{target.name.first_name} is dead!"}]
+            results = [{"message": f"{target.name.name_and_title()} is dead!"}]
         else:
-            results = [{"message": f"{target.name.first_name} is dead!"}]
+            results = [{"message": f"{target.name.name_and_title()} is dead!"}]
+
+        return results
+
+    def retreat(self, target):
+        results = []
+        if target.fighter.retreating == True:
+            results = [{"retreat": target}]
 
         return results
 
@@ -78,13 +85,17 @@ class Engine:
             if "dying" in action:
                 target = action["dying"]
                 self.dying(target)
+
+            if "retreat" in action:
+                target = action["retreat"]
+                eng.guild.team.move_entity_to_roster(target)
         
         self.action_queue = new_action_queue
-
 
     def _check_action_queue(self):
         for item in self.action_queue:
             print(item)
+
 
 # Instantiate & setup the engine
 eng = Engine()
@@ -104,6 +115,7 @@ eng.recruit_entity_to_guild(0)
 
 # Testing combat interactions between a team and Dungeon enemies
 
+
 def scripted_run():
     if len(eng.guild.team.members) == 0:
         return
@@ -112,46 +124,52 @@ def scripted_run():
 
     while eng.dungeon.boss.is_dead == False:
         for i, merc in enumerate(eng.guild.team.members):
-
             if not merc.is_dead:
                 if len(eng.dungeon.enemies) > 0:
-                    
+
                     eng.action_queue.extend(merc.fighter.attack(eng.dungeon.enemies[0]))
 
                     if eng.dungeon.enemies[0].is_dead:
                         eng.action_queue.extend(eng.dying(eng.dungeon.enemies[0]))
 
                     if merc.fighter.retreating == True:
-                        eng.guild.team.move_to_roster(i)
+                        # eng.guild.team.move_to_roster(i)
+                        eng.action_queue.extend(eng.retreat(merc))
+                        eng.process_action_queue()
+                    eng.process_action_queue()
 
                 if len(eng.dungeon.enemies) == 0 and not eng.dungeon.boss.is_dead:
 
                     eng.action_queue.extend(merc.fighter.attack(eng.dungeon.boss))
-                    
-                    if merc.fighter.retreating == True:
-                        eng.action_queue.append(
-                            {
-                                "message": f"{merc.name.first_name} retreats!"
-                            }
-                        )
-                        eng.guild.team.move_to_roster(i)
-                    
+
+                    # if merc.fighter.retreating == True:
+                    #     eng.action_queue.append(
+                    #         {"message": f"{merc.name.first_name} retreats!"}
+                    #     )
+                    #     eng.guild.team.move_to_roster(i)
+
                     if eng.dungeon.boss.is_dead:
                         eng.action_queue.extend(eng.dying(eng.dungeon.boss))
-
+                    eng.process_action_queue()
             if merc.is_dead:
                 eng.action_queue.extend(eng.dying(merc))
                 eng.guild.team.move_to_roster(i)
                 eng.guild.remove_from_roster(i)
-
+                eng.process_action_queue()
             eng.dungeon.remove_corpses()
 
         if len(eng.dungeon.enemies) > 0 and len(eng.guild.team.members) > 0:
-            eng.action_queue.extend(eng.dungeon.enemies[0].fighter.attack(eng.guild.team.members[0]))
+            eng.action_queue.extend(
+                eng.dungeon.enemies[0].fighter.attack(eng.guild.team.members[0])
+            )
+            eng.process_action_queue()
 
         if len(eng.dungeon.enemies) == 0 and not eng.dungeon.boss.is_dead:
             if len(eng.guild.team.members) > 0:
-                eng.action_queue.extend(eng.dungeon.boss.fighter.attack(eng.guild.team.members[0]))
+                eng.action_queue.extend(
+                    eng.dungeon.boss.fighter.attack(eng.guild.team.members[0])
+                )
+                eng.process_action_queue()
 
         # End states & Break.
         if len(eng.dungeon.enemies) == 0 and eng.dungeon.boss.is_dead:
@@ -162,20 +180,18 @@ def scripted_run():
                 )
             )
 
-            eng.action_queue.append(
-                {"message": message}
-            )
+            eng.action_queue.append({"message": message})
 
             print(f"guild claimed: {eng.dungeon.peek_reward()=}")
             eng.guild.claim_rewards(eng.dungeon)
 
             print(f"peek again: {eng.dungeon.peek_reward()=}")
+            eng.process_action_queue()
 
             break
 
         if len(eng.guild.team.members) == 0:
-            eng.action_queue.append(
-                {"message": f"{eng.guild.team.name} defeated!"}
-            )
+            eng.action_queue.append({"message": f"{eng.guild.team.name} defeated!"})
             # print(f"{eng.guild.team.name} defeated!")
+            eng.process_action_queue()
             break

--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -113,6 +113,11 @@ def scripted_run():
                     eng.action_queue.extend(merc.fighter.attack(eng.dungeon.boss))
                     
                     if merc.fighter.retreating == True:
+                        eng.action_queue.append(
+                            {
+                                "message": f"{merc.name.first_name} retreats!"
+                            }
+                        )
                         eng.guild.team.move_to_roster(i)
 
             if merc.is_dead:

--- a/src/entities/fighter.py
+++ b/src/entities/fighter.py
@@ -94,11 +94,5 @@ class Fighter:
                 }
             )
 
-            results.append(
-                {
-                    "message": f"{my_name} retreats!"
-                }
-            )
-
             self.retreating = True
             return results

--- a/src/entities/fighter.py
+++ b/src/entities/fighter.py
@@ -52,10 +52,10 @@ class Fighter:
         if self.hp <= 0:
             self.hp = 0
             self.owner.is_dead = True
+            
             results.append(
-                {"message": f"{self.owner.name.name_and_title()} is dead!"}
+                {"dying": self.owner}
             )
-            # print(f"{self.owner.name.name_and_title()} is dead!")
         
         return results
 

--- a/src/entities/fighter.py
+++ b/src/entities/fighter.py
@@ -6,6 +6,7 @@ from src.entities.entity import Entity
 class Fighter:
     def __init__(
         self,
+        is_enemy: bool,
         hp: int = 0,
         defence: int = 0,
         power: int = 0,
@@ -22,6 +23,7 @@ class Fighter:
         self.xp_reward = xp_reward
         self.current_xp = current_xp
         self.retreating = False
+        self.is_enemy = is_enemy
 
     def get_dict(self) -> dict:
         result = {
@@ -94,5 +96,12 @@ class Fighter:
                 }
             )
 
-            self.retreating = True
+            if self.is_enemy != True:
+                self.retreating = True
+                # results.append(
+                #     {
+                #         "retreat": self.owner
+                #     }
+                # )
+            # self.retreating = True
             return results

--- a/src/entities/fighter.py
+++ b/src/entities/fighter.py
@@ -21,6 +21,7 @@ class Fighter:
         self.level = level
         self.xp_reward = xp_reward
         self.current_xp = current_xp
+        self.retreating = False
 
     def get_dict(self) -> dict:
         result = {
@@ -44,18 +45,27 @@ class Fighter:
         self.current_xp = dict.get("current_xp")
 
     def take_damage(self, amount):
+        results = []
+
         self.hp -= amount
 
         if self.hp <= 0:
             self.hp = 0
             self.owner.is_dead = True
-            print(f"{self.owner.name.name_and_title()} is dead!")
+            results.append(
+                {"message": f"{self.owner.name.name_and_title()} is dead!"}
+            )
+            # print(f"{self.owner.name.name_and_title()} is dead!")
+        
+        return results
 
     def attack(self, target: Entity):
+        results = []
         if self.owner.is_dead or target.is_dead:
             raise ValueError(f"{self.owner.name}: he's dead jim.")
 
         my_name = self.owner.name.name_and_title()
+
         target_name = target.name.name_and_title()
 
         succesful_hit: int = self.power - target.fighter.defence
@@ -65,9 +75,30 @@ class Fighter:
                 2 * self.power**2 / (self.power + target.fighter.defence)
             )
 
-            print(f"{my_name} hits {target_name} for {actual_damage}\n")
-            target.fighter.take_damage(actual_damage)
+            results.append(
+                {
+                    "message": f"{my_name} hits {target_name} for {actual_damage}\n"
+                }
+            )
 
+            # print(f"{my_name} hits {target_name} for {actual_damage}\n")
+            result = target.fighter.take_damage(actual_damage)
+            results.extend(result)
+            
+            return results
+        
         else:
-            print(f"{my_name} fails to hit {target_name}!")
-            return 0
+            results.append(
+                {
+                    "message": f"{my_name} fails to hit {target_name}!"
+                }
+            )
+
+            results.append(
+                {
+                    "message": f"{my_name} retreats!"
+                }
+            )
+
+            self.retreating = True
+            return results

--- a/src/entities/fighter_factory.py
+++ b/src/entities/fighter_factory.py
@@ -11,15 +11,16 @@ class StatBlock(NamedTuple):
     hp: tuple[int, int]
     defence: tuple[int, int]
     power: tuple[int, int]
+    is_enemy: bool
 
     @property
     def factory(self) -> Factory:
         return get_fighter_factory(self)
 
 
-_mercenary = StatBlock(hp=(25, 25), defence=(1, 3), power=(3, 5))
-_monster = StatBlock(hp=(10, 10), defence=(1, 3), power=(1, 3))
-_boss = StatBlock(hp=(30, 30), defence=(2, 4), power=(2, 4))
+_mercenary = StatBlock(hp=(25, 25), defence=(1, 3), power=(3, 5), is_enemy=False)
+_monster = StatBlock(hp=(10, 10), defence=(1, 3), power=(1, 3), is_enemy=True)
+_boss = StatBlock(hp=(30, 30), defence=(2, 4), power=(2, 4), is_enemy=True)
 
 
 def get_fighter_factory(stats: StatBlock) -> Factory:
@@ -28,6 +29,7 @@ def get_fighter_factory(stats: StatBlock) -> Factory:
             hp=randint(*stats.hp),
             defence=randint(*stats.defence),
             power=randint(*stats.power),
+            is_enemy=stats.is_enemy
         )
         entity_name = Name(title=title, first_name=name, last_name=last_name)
         return Entity(name=entity_name, cost=randint(1, 5), fighter=fighter)

--- a/src/entities/guild.py
+++ b/src/entities/guild.py
@@ -99,3 +99,8 @@ class Team:
 
     def move_to_roster(self, selection):
         self.owner.roster.append(self.members.pop(selection))
+
+    def move_entity_to_roster(self, entity):
+        self.owner.roster.append(entity)
+        # print(self.members.index(entity))
+        self.members.pop(self.members.index(entity))

--- a/src/gui/views.py
+++ b/src/gui/views.py
@@ -302,8 +302,8 @@ class MissionsView(arcade.View):
         WindowData.width = width
         WindowData.height = height
 
-    def on_update(self, delta_time: float):
-        eng.process_action_queue()
+    # def on_update(self, delta_time: float):
+    #     eng.process_action_queue()
 
     def on_key_press(self, symbol: int, modifiers: int):
         match symbol:

--- a/src/gui/views.py
+++ b/src/gui/views.py
@@ -302,6 +302,9 @@ class MissionsView(arcade.View):
         WindowData.width = width
         WindowData.height = height
 
+    def on_update(self, delta_time: float):
+        eng.process_action_queue()
+
     def on_key_press(self, symbol: int, modifiers: int):
         match symbol:
             case arcade.key.G:


### PR DESCRIPTION
Setting up a centralised space in the Engine to handle various game actions.

Now, rather than displaying results of a combat action with a print() call as they happen, we can append a dict with a single key to a results array. The returned results array is appended to the engine.action_queue, which can then be processed with custom handling for each possible key, which can be processed by calling engine.process_action_queue(), probably from a Views on_update() hook.