### PR TITLE
Extract dispatcher class

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+_env = lambda type_, key, default: type_(os.getenv(key, default))
+
+DEBUG = _env(bool, "DEBUG", False)

--- a/src/engine/dispatcher.py
+++ b/src/engine/dispatcher.py
@@ -1,0 +1,83 @@
+import weakref
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from src.engine.engine import Engine, Handler
+
+from src import config
+from src.entities.dungeon import Dungeon
+from src.entities.entity import Entity
+from src.entities.fighter import Fighter
+from src.entities.guild import Guild
+
+
+class Dispatcher:
+    def __init__(self, engine: "Engine") -> None:
+        self.subscriptions: dict[str, dict[str, "Handler"]] = {}
+        self.eng = engine
+
+    def subscribe(
+        self,
+        topic: str,
+        handler_id: str,
+        handler: "Handler",
+        is_method=True,
+        keep_ref=False,
+    ):
+        if config.DEBUG:
+            print(f"{handler_id=} subscribed with {self.__class__} to {topic=}")
+        # check the subscription is a new one
+        subs = {}
+        if topic in self.subscriptions and handler_id in (
+            subs := self.subscriptions[topic]
+        ):
+            ref = self.subscriptions[topic][handler_id]
+            # ignore sub if the topic is already subscribed by that handler
+            if ref() is not None:
+                return
+
+        # IMPORTANT: we use a weakref to make sure we don't retain subscriptions
+        # from components that would otherwise be garbage collected.
+        if is_method and not keep_ref:
+            handler_ref = weakref.WeakMethod(handler)
+        else:
+            handler_ref = lambda: handler
+        self.subscriptions[topic] = {**subs, handler_id: handler_ref}
+
+    def publish(self, event: dict[str, Any]) -> None:
+        self._handle_subscriptions(event)
+
+    def _handle_subscriptions(self, event: dict[str, Any]) -> None:
+        # print(self.subscriptions)
+        for topic in event.keys():
+            subscribers = self.subscriptions.get(topic, {})
+
+            living_subs = {}
+            for subscriber_id, subscriber_ref in subscribers.items():
+                # Dereference the weakref, none if garbage collected
+                subscriber = subscriber_ref()
+
+                # since the subscriber is only a weakref, it might be stale, we handle that below
+                if subscriber is not None:
+                    # This is the case where the instance that owns the handler has strong refs
+                    # still kicking about, so we can keep the ref/id pair in the remaining subs for the
+                    # topic.
+                    living_subs[subscriber_id] = subscriber_ref
+                    subscriber(event)
+            # Actually replace the subscribers with the ones that remain after collection of garbage
+            self.subscriptions[topic] = living_subs
+
+    def flush_subs(self):
+        if config.DEBUG:
+            print(f"{self.__class__} flushed")
+        self.subscriptions: dict[str, dict[str, "Handler"]] = {}
+
+
+class VolatileDispatcher(Dispatcher):
+    def volatile_subscribe(self, topic: str, handler_id: str, handler: "Handler"):
+        self.subscribe(topic, handler_id, handler)
+
+
+class StaticDispatcher(Dispatcher):
+    def static_subscribe(self, topic: str, handler_id: str, handler: "Handler"):
+        self.subscribe(topic, handler_id, handler, keep_ref=True)

--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-from random import randint
-from typing import Any, Generator, NamedTuple, Optional, Callable
 import weakref
+from random import randint
+from typing import Any, Callable, Generator, NamedTuple, Optional
 
 from src.config.constants import guild_names
 from src.engine.describer import Describer
+from src.engine.dispatcher import StaticDispatcher, VolatileDispatcher
+from src.engine.game_state import AwardSpoilsHandler, GameState
 from src.entities.dungeon import Dungeon
 from src.entities.entity import Entity
 from src.entities.fighter import Fighter
 from src.entities.fighter_factory import EntityPool
 from src.entities.guild import Guild, Team
-from src.engine.game_state import GameState
 from src.entities.mission_board import MissionBoard
 from src.projection import health
 from src.systems.combat import CombatRound
@@ -29,12 +30,6 @@ Encounter = Generator[None, None, Round]
 Quest = Generator[None, None, Encounter]
 
 projections = {"entity_data": [health]}
-
-
-def flush_all() -> None:
-    for subscribers in projections.values():
-        for subscriber in subscribers:
-            subscriber.flush()
 
 
 Handler = Callable[[dict], None]
@@ -57,26 +52,29 @@ class Engine:
         self.mission_in_progress: bool = False
         self.current_room = None
         self.subscriptions: dict[str, dict[str, Handler]] = {}
-        self._handler_registry = set()
+        self.combat_dispatcher = VolatileDispatcher(self)
+        self.projection_dispatcher = StaticDispatcher(self)
+        self.projection_dispatcher.static_subscribe(
+            topic="entity_data",
+            handler_id="health_projection",
+            handler=health.consume,
+        )
+        self.projection_dispatcher.static_subscribe(
+            topic="flush",
+            handler_id="health_projection",
+            handler=health.flush_handler,
+        )
 
     def subscribe(self, topic: str, handler_id: str, handler: Handler):
-        # check the subscription is a new one
-        subs = {}
-        if topic in self.subscriptions and handler_id in (
-            subs := self.subscriptions[topic]
-        ):
-            ref = self.subscriptions[topic][handler_id]
-            # ignore sub if the topic is already subscribed by that handler
-            if ref() is not None:
-                return
-
-        # IMPORTANT: we use a weakref to make sure we don't retain subscriptions
-        # from components that would otherwise be garbage collected.
-        handler_ref = weakref.WeakMethod(handler)
-        self.subscriptions[topic] = {**subs, handler_id: handler_ref}
+        self.combat_dispatcher.subscribe(topic, handler_id, handler)
 
     def setup(self) -> None:
         self.game_state = GameState()
+        self.projection_dispatcher.static_subscribe(
+            topic="team triumphant",
+            handler_id="game_state",
+            handler=AwardSpoilsHandler(self.game_state).handle,
+        )
         # create a pool of potential recruits
         pool = EntityPool(15)
         pool.fill_pool()
@@ -89,7 +87,17 @@ class Engine:
         mission_board = MissionBoard(size=3)
         mission_board.fill_board(max_enemies_per_room=3, room_amount=3)
         self.game_state.set_mission_board(mission_board)
-        flush_all()
+        self.flush_all()
+
+    def flush_all(self):
+        self.flush_subscriptions()
+        self.flush_projections()
+
+    def flush_subscriptions(self):
+        self.combat_dispatcher.flush_subs()
+
+    def flush_projections(self):
+        self.projection_dispatcher.publish({"flush": None})
 
     def recruit_entity_to_guild(self, selection_id) -> None:
         guild = self.game_state.get_guild()
@@ -107,63 +115,27 @@ class Engine:
             self.process_one(event)
 
     def process_one(self, event: Action) -> None:
+        if "cleanup" in event:
+            self.flush_all()
+            return
+
+        if "delay" in event:
+            # Purely an instruction to the engine
+            self._handle_delay_action(event)
+            del event["delay"]
+
+        if "await_input" in event:
+            self.await_input()
+            del event["await_input"]
+
         if "message" in event:
             self.messages.append(event["message"])
 
-        if "await target" in event:
-            fighter = event["await target"]
-            self.await_input()
+        self.projection_dispatcher.publish(event)
+        self.combat_dispatcher.publish(event)
 
-        to_project = {*event.keys()} & {*projections.keys()}
-        for key in to_project:
-            for projection in projections[key]:
-                projection.consume(action=event)
-
-        self._handle_subscriptions(event)
-
-        if "delay" in event:
-            delay = event["delay"]
-            self.increase_update_clock_by_delay(delay)
-
-        if "dying" in event:
-            entity: Entity = event["dying"]
-
-        if "retreat" in event:
-            fighter: Fighter = event["retreat"]
-
-            if fighter.owner.is_dead == False:
-                self.game_state.guild.team.move_fighter_to_roster(fighter.owner)
-
-        if "team triumphant" in event:
-            guild: Guild = event["team triumphant"][0]
-            dungeon: Dungeon = event["team triumphant"][1]
-            dungeon.cleared = True
-            guild.claim_rewards(dungeon)
-
-    def _handle_subscriptions(self, event: dict) -> None:
-        # print(self.subscriptions)
-        for topic in event.keys():
-            subscribers = self.subscriptions.get(topic, {})
-
-            living_subs = {}
-            for subscriber_id, subscriber_ref in subscribers.items():
-                # Dereference the weakref, none if garbage collected
-                subscriber = subscriber_ref()
-
-                # since the subscriber is only a weakref, it might be stale, we handle that below
-                if subscriber is not None:
-                    # This is the case where the instance that owns the handler has strong refs
-                    # still kicking about, so we can keep the ref/id pair in the remaining subs for the
-                    # topic.
-                    living_subs[subscriber_id] = subscriber_ref
-                    subscriber(event)
-            print(living_subs)
-            # Actually replace the subscribers with the ones that remain after collection of garbage
-            self.subscriptions[topic] = living_subs
-
-    def _check_action_queue(self) -> None:
-        for item in self.action_queue:
-            print(f"item: {item}")
+    def _handle_delay_action(self, event):
+        self.increase_update_clock_by_delay(event.get("delay", 0))
 
     def reset_update_clock(self):
         self.update_clock = self.default_clock_value
@@ -213,7 +185,6 @@ class Engine:
         self.messages = []
         self.message_alphas = []
         self.alpha_max = 255
-        flush_all()
         self.combat = self._generate_combat_actions()
 
     def initial_health_values(self, team, enemies) -> list[Action]:
@@ -306,7 +277,7 @@ class Engine:
 
         for action in self.end_of_combat(win=win):
             yield action
-        
+
         yield {"cleanup": encounter}
 
     @staticmethod
@@ -321,7 +292,7 @@ class Engine:
         )
 
         results.append({"message": message})
-        results.append({"team triumphant": (guild, dungeon)})
+        results.append({"team triumphant": {"dungeon": dungeon}})
         return results
 
     @staticmethod

--- a/src/engine/engine.py
+++ b/src/engine/engine.py
@@ -29,8 +29,6 @@ Round = Generator[None, None, Turn]  # <- These are internal to the combat syste
 Encounter = Generator[None, None, Round]
 Quest = Generator[None, None, Encounter]
 
-projections = {"entity_data": [health]}
-
 
 Handler = Callable[[dict], None]
 

--- a/src/engine/game_state.py
+++ b/src/engine/game_state.py
@@ -1,11 +1,11 @@
-from typing import Optional
 from random import randint
+from typing import Optional
 
-from src.entities.guild import Guild, Team
-from src.entities.fighter_factory import EntityPool
-from src.entities.dungeon import Dungeon
-from src.entities.mission_board import MissionBoard
 from src.config.constants import guild_names
+from src.entities.dungeon import Dungeon
+from src.entities.fighter_factory import EntityPool
+from src.entities.guild import Guild, Team
+from src.entities.mission_board import MissionBoard
 
 
 class GameState:
@@ -54,3 +54,18 @@ class GameState:
 
     def set_mission_board(self, board):
         self.mission_board = board
+
+
+class AwardSpoilsHandler:
+    def __init__(self, state: GameState):
+        self.state = state
+
+    def handle(self, event):
+        """
+        code etc
+        """
+        dungeon = event.get("team triumphant", {}).get("dungeon")
+        if dungeon is None:
+            return
+        dungeon.cleared = True
+        self.state.guild.claim_rewards(dungeon)

--- a/src/entities/dungeon.py
+++ b/src/entities/dungeon.py
@@ -27,11 +27,13 @@ class Room:
             self.enemies.append(entity)
         entity.on_death_hooks.append(self.remove)
         entity.on_death_hooks.append(Entity.flush_locatable)
+        entity.fighter.on_retreat_hooks.append(self.remove)
+        entity.fighter.on_retreat_hooks.append(Entity.flush_locatable)
 
     def include_party(self, party: list[Entity]) -> None:
         for member in party:
             self.add_entity(member)
-        
+
     def mob_spawns_points(self) -> Generator[Node, None, None]:
         left_wall = {Node(x=0, y=y) for y in self.space.y_range}
         while True:

--- a/src/entities/fighter.py
+++ b/src/entities/fighter.py
@@ -21,7 +21,7 @@ class Fighter:
         xp_reward: int = 0,
         current_xp: int = 0,
         speed: int = 0,
-        is_boss: bool = False
+        is_boss: bool = False,
     ) -> None:
         self.owner: Optional[Entity] = None
         self.max_hp = hp
@@ -32,6 +32,7 @@ class Fighter:
         self.xp_reward = xp_reward
         self.current_xp = current_xp
         self.retreating = False
+        self.on_retreat_hooks = []
         self.is_enemy = is_enemy
         self.is_boss = is_boss
         self.target = None
@@ -61,7 +62,7 @@ class Fighter:
     def request_target(self) -> Action:
         return {
             "message": f"{self.owner.name.name_and_title} readies their attack! Choose a target!",
-            "await target": self,
+            "await_input": self,
         }
 
     def choose_target(self, targets) -> int:
@@ -179,6 +180,11 @@ class Fighter:
             result.update(**{"message": f"{my_name} fails to hit {target_name}!"})
 
             if self.is_enemy != True:
-                self.retreating = True
+                self.commence_retreat()
 
         return result
+
+    def commence_retreat(self):
+        self.retreating = True
+        for hook in self.on_retreat_hooks:
+            hook(self)

--- a/src/entities/guild.py
+++ b/src/entities/guild.py
@@ -101,6 +101,7 @@ class Team:
         entity.on_death_hooks = []
 
         entity.on_death_hooks.append(self.remove_dead_member)
+        entity.fighter.on_retreat_hooks.append(self.move_fighter_to_roster)
 
         entity.fighter.retreating = False
         self.members.append(entity)

--- a/src/gui/views.py
+++ b/src/gui/views.py
@@ -11,9 +11,9 @@ from src.gui.buttons import get_new_missions_button, nav_button
 from src.gui.combat_screen import CombatScreen
 from src.gui.gui_components import box_containing_horizontal_label_pair
 from src.gui.gui_utils import Cycle
-from src.gui.sections import (CommandBarSection, InfoPaneSection,
-                              MissionsSection, RecruitmentPaneSection,
-                              RosterAndTeamPaneSection, CombatGridSection)
+from src.gui.sections import (CombatGridSection, CommandBarSection,
+                              InfoPaneSection, MissionsSection,
+                              RecruitmentPaneSection, RosterAndTeamPaneSection)
 from src.gui.states import ViewStates
 from src.gui.window_data import WindowData
 
@@ -124,7 +124,6 @@ class GuildView(arcade.View):
         # Add sections to section manager.
         self.add_section(self.info_pane_section)
         self.add_section(self.command_bar_section)
-        
 
     def on_show_view(self) -> None:
         self.info_pane_section.manager.enable()
@@ -447,7 +446,7 @@ class MissionsView(arcade.View):
         self.selection = Cycle(
             3, 2
         )  # 3 missions on screen, default selected (2) is the top visually.
-        
+
         self.mission_section = MissionsSection(
             left=0,
             bottom=242,
@@ -497,7 +496,7 @@ class MissionsView(arcade.View):
         self.add_section(self.mission_section)
         self.add_section(self.info_pane_section)
         self.add_section(self.command_bar_section)
-    
+
     def on_show_view(self) -> None:
         self.mission_section.manager.enable()
         self.info_pane_section.manager.enable()
@@ -527,10 +526,10 @@ class MissionsView(arcade.View):
         self.command_bar_section.manager.disable()
         self.info_pane_section.manager.disable()
         self.mission_section.manager.disable()
-        
+
     def on_draw(self) -> None:
         self.clear()
-    
+
     def on_resize(self, width: int, height: int) -> None:
         super().on_resize(width, height)
         WindowData.width = width
@@ -553,8 +552,7 @@ class MissionsView(arcade.View):
                 eng.init_dungeon()
                 if not eng.game_state.dungeon.cleared:
                     if len(eng.game_state.guild.team.members) > 0:
-                        battle = BattleView()
-                        self.window.show_view(battle)
+                        self.window.show_view(BattleView())
 
 
 class BattleView(arcade.View):
@@ -564,24 +562,24 @@ class BattleView(arcade.View):
             left=0,
             bottom=WindowData.height / 2,
             width=WindowData.width,
-            height=WindowData.height /2,
+            height=WindowData.height / 2,
             prevent_dispatch_view={False},
         )
-        
+
         self.add_section(self.combat_grid_section)
-        
-    def on_show_view(self):
         eng.init_combat()
+
+    def on_show_view(self):
         eng.await_input()
-    
+
     def on_draw(self):
         self.clear()
-    
+
     def on_key_press(self, symbol: int, modifiers: int) -> None:
         match symbol:
             case arcade.key.G:
                 if eng.mission_in_progress is False:
-                    eng.subscriptions = {}
+                    eng.flush_subscriptions()
                     guild_view = GuildView()
                     self.window.show_view(guild_view)
 
@@ -601,7 +599,7 @@ class BattleView(arcade.View):
                 if eng.awaiting_input:
                     eng.next_combat_action()
                     eng.awaiting_input = False
-    
+
     def on_resize(self, width: int, height: int) -> None:
         super().on_resize(width, height)
         WindowData.width = width

--- a/src/projection/health.py
+++ b/src/projection/health.py
@@ -102,8 +102,5 @@ def consume(action: dict[str, Any]) -> None:
             _health_projection.pop(name)
 
 
-def get_subscription() -> set[str]:
-    """
-    registers this module as a consumer of events with the returned keys present
-    """
-    return {_KEY}
+def flush_handler(event):
+    flush()


### PR DESCRIPTION
Changes:
 - Added Dispatcher component
 - Made Static vs Volatile versions (not enforced, but helpful for semantics, for now)
 - Cleaned up some of the state change vs engine control logic in the Engine.process_one implementation
 - Set up on_retreat_hooks in fighter since as of generator architecture, team members could not die while retreating.
 - Unified projections implementation with dispatcher pattern using the static dispatcher.
 - The `set_encounter` and other subscribers for `CombatGridSection` instances are now handled by the `VolatileDispatcher` which is flushed at the end of combat to clear out any dangling weakrefs.