### PR TITLE
SpriteSheet quick naming revert

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -188,6 +188,12 @@ dungeon_descriptors = {
 
 enemy_types = [
     "Goblin",
+    "Goblin",
+    "Goblin",
+    "Goblin",
+    "Slime",
+    "Slime",
+    "Slime",
     "Slime",
 ]
 

--- a/src/entities/dungeon_factory.py
+++ b/src/entities/dungeon_factory.py
@@ -40,7 +40,7 @@ def create_random_enemy_room(enemy_amount) -> Room:
     room = Room()
 
     for enemy in range(enemy_amount):
-        room.add_entity(create_random_monster(f"{choice(enemy_types)}", None))
+        room.add_entity(create_random_monster(f"{choice(enemy_types)} {enemy}", None))
 
     return room
 

--- a/src/entities/fighter_factory.py
+++ b/src/entities/fighter_factory.py
@@ -48,17 +48,18 @@ def get_fighter_factory(stats: StatBlock) -> Factory:
         Set up textures for the fighter.
         As we have the name already, use that to determine particular enemy textures for hostile fighters.
         """
+        print(entity_name.name_and_title)
         match (fighter.is_enemy, fighter.is_boss):
             case (False, False):
                 merc = choice([MercenaryOneTextures, MercenaryTwoTextures, MercenaryThreeTextures, MercenaryFourTextures])
                 idle_textures, attack_textures = mercenary_textures(merc)
                 
             case (True, False):
-                if entity_name.name_and_title == enemy_types[0]:
+                if "Goblin" in  entity_name.name_and_title:
                     enemy = choice([GoblinOneTextures, GoblinTwoTextures, GoblinThreeTextures, GoblinFourTextures])
                     idle_textures, attack_textures = goblin_textures(enemy)
                 
-                if entity_name.name_and_title == enemy_types[1]:
+                if "Slime" in entity_name.name_and_title:
                     enemy = SlimeTexture
                     idle_textures, attack_textures = slime_textures(enemy)
             


### PR DESCRIPTION
Quick fix for a not-thought out change for application of names to enemy entities.