### PR TITLE
Implemented offset sprite

### DIFF
--- a/run_linting.sh
+++ b/run_linting.sh
@@ -1,0 +1,4 @@
+#/usr/bin/env sh
+
+black .
+isort .

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,2 @@
+#/usr/bin/env bash
 python -m unittest discover src/tests

--- a/src/entities/dungeon.py
+++ b/src/entities/dungeon.py
@@ -11,7 +11,7 @@ class Room:
         self.occupants: list[Entity] = []
         self._cleared = False
         self.space = Space(Node(x=0, y=0), Node(*size), exclusions=set())
-        self.entry_door = Node(x=0, y=5)
+        self.entry_door = Node(x=0, y=5) if size[1] > 5 else Node(0, 0)
 
     def update_pathing_obstacles(self):
         """

--- a/src/entities/dungeon_factory.py
+++ b/src/entities/dungeon_factory.py
@@ -1,17 +1,11 @@
 from random import choice, randint
 
-from src.config.constants import (
-    boss_names,
-    boss_titles,
-    dungeon_descriptors,
-    enemy_types,
-)
+from src.config.constants import (boss_names, boss_titles, dungeon_descriptors,
+                                  enemy_types)
 from src.entities.dungeon import Dungeon, Room
-from src.entities.fighter_factory import (
-    create_random_boss,
-    create_random_goblin,
-    create_random_monster,
-)
+from src.entities.fighter_factory import (create_random_boss,
+                                          create_random_goblin,
+                                          create_random_monster)
 
 
 def describe_dungeon() -> str:

--- a/src/entities/entity.py
+++ b/src/entities/entity.py
@@ -31,6 +31,8 @@ class Species:
 
 
 class Entity:
+    entity_sprite: EntitySprite | None
+
     def __init__(
         self,
         sprite=None,
@@ -59,8 +61,8 @@ class Entity:
 
         self.locatable = None
 
-    def set_entity_sprite(self, sprite):
-        self.entity_sprite: EntitySprite = sprite
+    def set_entity_sprite(self, sprite: EntitySprite):
+        self.entity_sprite = sprite
         if self.entity_sprite:
             self.entity_sprite.owner = self
 

--- a/src/entities/fighter_factory.py
+++ b/src/entities/fighter_factory.py
@@ -131,9 +131,6 @@ def get_fighter_factory(stats: StatBlock, attach_sprites: bool = True) -> Factor
         )
 
     def _attach_sprites(entity: Entity) -> Entity:
-        if entity.fighter is None:
-            breakpoint()
-
         atk_one, atk_two, idle_one, idle_two = select_textures(
             entity.species, entity.fighter
         )

--- a/src/gui/sections.py
+++ b/src/gui/sections.py
@@ -12,15 +12,12 @@ from src.entities.dungeon import Room
 from src.entities.sprites import OffsetSprite
 from src.gui.buttons import CommandBarMixin
 from src.gui.combat_screen import CombatScreen
-from src.gui.gui_components import (
-    box_containing_horizontal_label_pair,
-    create_colored_UILabel_header,
-    entity_labels_names_only,
-    entity_labels_with_cost,
-    horizontal_box_pair,
-    single_box,
-    vstack_of_three_boxes,
-)
+from src.gui.gui_components import (box_containing_horizontal_label_pair,
+                                    create_colored_UILabel_header,
+                                    entity_labels_names_only,
+                                    entity_labels_with_cost,
+                                    horizontal_box_pair, single_box,
+                                    vstack_of_three_boxes)
 from src.gui.gui_utils import Cycle, ScrollWindow
 from src.gui.selection_texture_enums import SelectionCursor
 from src.gui.states import MissionCards
@@ -817,20 +814,20 @@ class CombatGridSection(arcade.Section):
         selected_path_sprites = arcade.SpriteList()
         start_sprite = OffsetSprite(
             WindowData.indicators[SelectionCursor.GREEN.value], cls.SPRITE_SCALE
-        ).offset_anchor((0, 5.5))
+        ).offset_anchor((0, 4.5))
         start_sprite.visible = False
         selected_path_sprites.append(start_sprite)
         for _ in range(1, 19):
             sprite_tex = WindowData.indicators[SelectionCursor.GOLD_EDGE.value]
             sprite = OffsetSprite(sprite_tex, scale=cls.SPRITE_SCALE).offset_anchor(
-                (0, 5)
+                (0, 3.5)
             )
             selected_path_sprites.append(sprite)
             sprite.visible = False
 
         end_sprite = OffsetSprite(
             WindowData.indicators[SelectionCursor.RED.value], cls.SPRITE_SCALE
-        ).offset_anchor((0, 5.5))
+        ).offset_anchor((0, 4.5))
         selected_path_sprites.append(end_sprite)
         end_sprite.visible = False
 

--- a/src/gui/sections.py
+++ b/src/gui/sections.py
@@ -9,6 +9,7 @@ from pyglet.math import Vec2
 from src import config
 from src.engine.init_engine import eng
 from src.entities.dungeon import Room
+from src.entities.sprites import OffsetSprite
 from src.gui.buttons import CommandBarMixin
 from src.gui.combat_screen import CombatScreen
 from src.gui.gui_components import (
@@ -814,20 +815,22 @@ class CombatGridSection(arcade.Section):
     @classmethod
     def init_path(cls) -> arcade.SpriteList:
         selected_path_sprites = arcade.SpriteList()
-        start_sprite = arcade.Sprite(
+        start_sprite = OffsetSprite(
             WindowData.indicators[SelectionCursor.GREEN.value], cls.SPRITE_SCALE
-        )
+        ).offset_anchor((0, 5.5))
         start_sprite.visible = False
         selected_path_sprites.append(start_sprite)
         for _ in range(1, 19):
             sprite_tex = WindowData.indicators[SelectionCursor.GOLD_EDGE.value]
-            sprite = arcade.Sprite(sprite_tex, scale=cls.SPRITE_SCALE)
+            sprite = OffsetSprite(sprite_tex, scale=cls.SPRITE_SCALE).offset_anchor(
+                (0, 5)
+            )
             selected_path_sprites.append(sprite)
             sprite.visible = False
 
-        end_sprite = arcade.Sprite(
+        end_sprite = OffsetSprite(
             WindowData.indicators[SelectionCursor.RED.value], cls.SPRITE_SCALE
-        )
+        ).offset_anchor((0, 5.5))
         selected_path_sprites.append(end_sprite)
         end_sprite.visible = False
 
@@ -951,6 +954,8 @@ class CombatGridSection(arcade.Section):
         for dude in self.encounter_room.occupants:
             if dude.fighter.is_boss:
                 dude.entity_sprite.sprite.scale = dude.entity_sprite.sprite.scale * 1.5
+            if dude.locatable.location is None:
+                breakpoint()
             dude.entity_sprite.sprite.position = self.to_screen(dude.locatable.location)
 
             dude.entity_sprite.orient(dude.locatable.orientation)
@@ -987,7 +992,7 @@ class CombatGridSection(arcade.Section):
             if i in visible:
                 node_idx = i if i in head + body else -1
                 node = current[node_idx]
-                position = self.to_screen(node) - Vec2(0, 4) * self.SPRITE_SCALE
+                position = self.to_screen(node)
                 sprite.visible = True
                 sprite.center_x, sprite.center_y = position.x, position.y
             elif i in invisible:

--- a/src/gui/sections.py
+++ b/src/gui/sections.py
@@ -951,8 +951,6 @@ class CombatGridSection(arcade.Section):
         for dude in self.encounter_room.occupants:
             if dude.fighter.is_boss:
                 dude.entity_sprite.sprite.scale = dude.entity_sprite.sprite.scale * 1.5
-            if dude.locatable.location is None:
-                breakpoint()
             dude.entity_sprite.sprite.position = self.to_screen(dude.locatable.location)
 
             dude.entity_sprite.orient(dude.locatable.orientation)

--- a/src/gui/views.py
+++ b/src/gui/views.py
@@ -10,14 +10,9 @@ from src.engine.init_engine import eng
 from src.gui.buttons import get_new_missions_button, nav_button
 from src.gui.gui_components import box_containing_horizontal_label_pair
 from src.gui.gui_utils import Cycle
-from src.gui.sections import (
-    CombatGridSection,
-    CommandBarSection,
-    InfoPaneSection,
-    MissionsSection,
-    RecruitmentPaneSection,
-    RosterAndTeamPaneSection,
-)
+from src.gui.sections import (CombatGridSection, CommandBarSection,
+                              InfoPaneSection, MissionsSection,
+                              RecruitmentPaneSection, RosterAndTeamPaneSection)
 from src.gui.states import ViewStates
 from src.gui.window_data import WindowData
 from src.utils.input_capture import Selection

--- a/src/world/pathing/grid_utils.py
+++ b/src/world/pathing/grid_utils.py
@@ -24,10 +24,12 @@ class Space(AStar):
         self.exclusions = exclusions
 
     def __contains__(self, item: Node) -> bool:
-        x_within = self.minima.x <= item.x < self.maxima.x
-        y_within = self.minima.y <= item.y < self.maxima.y
+        return self.in_bounds(item) and item not in self.exclusions
 
-        return x_within and y_within and item not in self.exclusions
+    def in_bounds(self, node: Node) -> bool:
+        x_within = self.minima.x <= node.x < self.maxima.x
+        y_within = self.minima.y <= node.y < self.maxima.y
+        return x_within and y_within
 
     def neighbors(self, node: Node) -> Generator[Node, None, None]:
         for candidate in node.adjacent:
@@ -131,7 +133,11 @@ class Space(AStar):
 
         tried = {attempt}  # will be empty if node not excluded
 
-        while (attempt := random.choice([*attempt.adjacent])) not in self:
+        while (
+            attempt := random.choice(
+                [adj for adj in attempt.adjacent if self.in_bounds(adj)]
+            )
+        ) not in self:
             tried.add(attempt)
             # if we've tried every unique node
             if len(tried) == len(self):

--- a/src/world/pathing/grid_utils.py
+++ b/src/world/pathing/grid_utils.py
@@ -132,7 +132,7 @@ class Space(AStar):
             return attempt
 
         tried = {attempt}  # will be empty if node not excluded
-
+        breakpoint()
         while (
             attempt := random.choice(
                 [adj for adj in attempt.adjacent if self.in_bounds(adj)]

--- a/src/world/pathing/grid_utils.py
+++ b/src/world/pathing/grid_utils.py
@@ -132,7 +132,6 @@ class Space(AStar):
             return attempt
 
         tried = {attempt}  # will be empty if node not excluded
-        breakpoint()
         while (
             attempt := random.choice(
                 [adj for adj in attempt.adjacent if self.in_bounds(adj)]


### PR DESCRIPTION
 - Implemented a mixin to override the `center_x`, `center_y`, and `position` setters and getters for a sprite to include a configurable offset.
 - The offset has the semantics of changing where the anchor is in texture pixel units.
 - Fixed a bug in the algorithm that places adventurers in a room initially which meant that the random walk could just go out of bounds forever, leading to locatable positions being None.