### PR TITLE
Unified all combat view sprites in single list

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,2 +1,6 @@
-#/usr/bin/env bash
-python -m unittest discover src/tests
+#!/usr/bin/env bash
+if [ "$#" -gt 0 ]; then 
+	python -m unittest discover "$1"
+else
+	python -m unittest discover src/tests
+fi

--- a/src/entities/dungeon.py
+++ b/src/entities/dungeon.py
@@ -9,15 +9,17 @@ from src.world.pathing.pathing_space import PathingSpace
 
 class Room:
     def __init__(self, size: tuple[int, int] = (10, 10)) -> None:
-        self.layout = basic_room(size)
+        self.layout = None
+        self.space = None
+        self.set_layout(basic_room(size))
         self.enemies: list[Entity] = []
         self.occupants: list[Entity] = []
         self._cleared = False
-        self.space = PathingSpace.from_level_geometry(self.layout)
         self.entry_door = Node(x=0, y=5) if size[1] > 5 else Node(0, 0)
 
     def set_layout(self, layout: tuple[Node, ...]) -> Self:
         self.layout = layout
+        self.space = PathingSpace.from_level_geometry(self.layout)
         return self
 
     def update_pathing_obstacles(self):

--- a/src/entities/dungeon_factory.py
+++ b/src/entities/dungeon_factory.py
@@ -7,7 +7,7 @@ from src.entities.fighter_factory import (
     create_random_goblin,
     create_random_monster,
 )
-from src.world.level.room import boss_room
+from src.world.level.room import random_room
 
 
 def describe_dungeon() -> str:
@@ -41,7 +41,7 @@ def create_random_dungeon(enemy_amount) -> Dungeon:
 
 # Room testing with Room Class
 def create_random_enemy_room(enemy_amount) -> Room:
-    room = Room()
+    room = Room().set_layout(random_room((10, 10)))
 
     for enemy in range(enemy_amount):
         roll = randint(0, 3)
@@ -54,7 +54,7 @@ def create_random_enemy_room(enemy_amount) -> Room:
 
 
 def create_random_boss_room() -> Room:
-    room = Room().set_layout(boss_room((10, 10)))
+    room = Room().set_layout(random_room((10, 10)))
 
     room.add_entity(
         create_random_boss(

--- a/src/gui/sections.py
+++ b/src/gui/sections.py
@@ -9,7 +9,8 @@ from pyglet.math import Vec2
 from src import config
 from src.engine.init_engine import eng
 from src.entities.dungeon import Room
-from src.entities.sprites import BaseSprite, OffsetSprite
+from src.entities.entity import Entity
+from src.entities.sprites import BaseSprite
 from src.gui.buttons import CommandBarMixin
 from src.gui.combat_screen import CombatScreen
 from src.gui.gui_components import (
@@ -794,45 +795,21 @@ class CombatGridSection(arcade.Section):
         self.encounter_room = None
         self._original_dims = width, height
 
-        self.tile_sprite_list = arcade.SpriteList()
+        self.world_sprite_list = arcade.SpriteList()
         self.dudes_sprite_list = arcade.SpriteList()
         self.combat_screen = CombatScreen()
         self.grid_camera = arcade.Camera()
         self.grid_camera.zoom = 1.0
         self.other_camera = arcade.Camera()
         self._subscribe_to_events()
-        self.selected_path_sprites = self.init_path()
         self.cam_controls = CameraController(self.grid_camera)
-        self.transform = Transform(
-            block_dimensions=(16, 8, 8), absolute_scale=self.SPRITE_SCALE
+
+        self.transform = Transform.isometric(
+            block_dimensions=(16, 8, 8),
+            absolute_scale=self.SPRITE_SCALE,
+            translation=Vec2(self.width, self.height) / 2,
         )
-
-    def to_screen(self, node: Node) -> Vec2:
-        return self.transform.to_screen(node) + Vec2(self.width, self.height) / 2
-
-    @classmethod
-    def init_path(cls) -> arcade.SpriteList:
-        selected_path_sprites = arcade.SpriteList()
-        start_sprite = OffsetSprite(
-            WindowData.indicators[SelectionCursor.GREEN.value], cls.SPRITE_SCALE
-        ).offset_anchor((0, 4.5))
-        start_sprite.visible = False
-        selected_path_sprites.append(start_sprite)
-        for _ in range(1, 19):
-            sprite_tex = WindowData.indicators[SelectionCursor.GOLD_EDGE.value]
-            sprite = OffsetSprite(sprite_tex, scale=cls.SPRITE_SCALE).offset_anchor(
-                (0, 3.5)
-            )
-            selected_path_sprites.append(sprite)
-            sprite.visible = False
-
-        end_sprite = OffsetSprite(
-            WindowData.indicators[SelectionCursor.RED.value], cls.SPRITE_SCALE
-        ).offset_anchor((0, 4.5))
-        selected_path_sprites.append(end_sprite)
-        end_sprite.visible = False
-
-        return selected_path_sprites
+        self.all_path_sprites = self.init_path()
 
     def _subscribe_to_events(self):
         eng.combat_dispatcher.volatile_subscribe(
@@ -849,8 +826,8 @@ class CombatGridSection(arcade.Section):
 
         eng.combat_dispatcher.volatile_subscribe(
             topic="cleanup",
-            handler_id="CombatGrid.clear_occupants",
-            handler=self.clear_occupants,
+            handler_id="CombatGrid.teardown_level",
+            handler=self.teardown_level,
         )
 
         eng.combat_dispatcher.volatile_subscribe(
@@ -860,16 +837,81 @@ class CombatGridSection(arcade.Section):
         )
 
         eng.combat_dispatcher.volatile_subscribe(
-            topic="dead",
+            topic="dying",
+            handler_id="CombatGrid.clear_dead_sprites",
+            handler=self.clear_dead_sprites,
+        )
+        eng.combat_dispatcher.volatile_subscribe(
+            topic="retreat",
             handler_id="CombatGrid.clear_dead_sprites",
             handler=self.clear_dead_sprites,
         )
 
-    def clear_occupants(self, event):
-        encounter = event["cleanup"]
-        for occupant in encounter.occupants:
-            if not occupant.fighter.is_enemy:
-                encounter.remove(occupant)
+    def init_path(self) -> arcade.SpriteList:
+        selected_path_sprites = arcade.SpriteList()
+        start_sprite = BaseSprite(
+            WindowData.indicators[SelectionCursor.GREEN.value],
+            scale=self.SPRITE_SCALE,
+            transform=self.transform,
+            draw_priority_offset=0.1,
+        ).offset_anchor((0, 4.5))
+        selected_path_sprites.append(start_sprite)
+
+        main_path_tex = WindowData.indicators[SelectionCursor.GOLD_EDGE.value]
+        for _ in range(1, 19):
+            sprite = BaseSprite(
+                main_path_tex,
+                scale=self.SPRITE_SCALE,
+                transform=self.transform,
+                draw_priority_offset=0.1,
+            ).offset_anchor((0, 3.5))
+
+            selected_path_sprites.append(sprite)
+
+        end_sprite = BaseSprite(
+            WindowData.indicators[SelectionCursor.RED.value],
+            scale=self.SPRITE_SCALE,
+            transform=self.transform,
+            draw_priority_offset=0.1,
+        ).offset_anchor((0, 4.5))
+
+        selected_path_sprites.append(end_sprite)
+
+        return selected_path_sprites
+
+    def show_path(self, current: tuple[Node]):
+        head = (0,)
+        body = tuple(range(1, len(current) - 1))
+        tail = (19,)
+        rest = range(len(current) - 1, 19)
+
+        visible = [*head, *body, *tail]
+        invisible = rest
+
+        for i, sprite in enumerate(self.all_path_sprites):
+            if i in visible:
+                node_idx = i if i in head + body else -1
+                node = current[node_idx]
+                sprite.set_node(node)
+                if sprite not in self.world_sprite_list:
+                    self.world_sprite_list.append(sprite)
+
+            elif i in invisible:
+                sprite.visible = True
+                if sprite in self.world_sprite_list:
+                    self.world_sprite_list.remove(sprite)
+
+        self.refresh_draw_order()
+
+    def hide_path(self):
+        for sprite in self.all_path_sprites:
+            if sprite in self.world_sprite_list:
+                self.world_sprite_list.remove(sprite)
+
+        self.refresh_draw_order()
+
+    def refresh_draw_order(self):
+        self.world_sprite_list.sort(key=lambda s: s.get_draw_priority())
 
     def on_update(self, delta_time: float):
         self.cam_controls.on_update()
@@ -890,9 +932,7 @@ class CombatGridSection(arcade.Section):
     def on_draw(self):
         self.grid_camera.use()
 
-        self.tile_sprite_list.draw(pixelated=True)
-        self.selected_path_sprites.draw(pixelated=True)
-        self.dudes_sprite_list.draw(pixelated=True)
+        self.world_sprite_list.draw(pixelated=True)
 
         self.other_camera.use()
         if config.DEBUG:
@@ -932,11 +972,13 @@ class CombatGridSection(arcade.Section):
             self.update_dudes(event)
 
     def level_to_sprite_list(self):
-        self.tile_sprite_list.clear()
+        self.world_sprite_list.clear()
         for node in self.encounter_room.layout:
-            sprite = arcade.Sprite(WindowData.tiles[89], scale=self.SPRITE_SCALE)
-            sprite.position = self.to_screen(node)
-            self.tile_sprite_list.append(sprite)
+            sprite = BaseSprite(
+                WindowData.tiles[89], scale=self.SPRITE_SCALE, transform=self.transform
+            )
+            sprite.set_node(node)
+            self.world_sprite_list.append(sprite)
 
     def prepare_dude_sprites(self):
         """
@@ -951,9 +993,11 @@ class CombatGridSection(arcade.Section):
         for dude in self.encounter_room.occupants:
             if dude.fighter.is_boss:
                 dude.entity_sprite.sprite.scale = dude.entity_sprite.sprite.scale * 1.5
-            dude.entity_sprite.sprite.position = self.to_screen(dude.locatable.location)
+            dude.entity_sprite.sprite.set_transform(self.transform)
+            dude.entity_sprite.sprite.set_node(dude.locatable.location)
 
             dude.entity_sprite.orient(dude.locatable.orientation)
+            self.world_sprite_list.append(dude.entity_sprite.sprite)
             self.dudes_sprite_list.append(dude.entity_sprite.sprite)
 
     def update_dudes(self, _: dict) -> None:
@@ -970,32 +1014,14 @@ class CombatGridSection(arcade.Section):
             return
 
         for dude in self.encounter_room.occupants:
-            dude.entity_sprite.sprite.position = self.to_screen(dude.locatable.location)
+            dude.entity_sprite.sprite.set_node(dude.locatable.location)
             dude.entity_sprite.orient(dude.locatable.orientation)
-        self.dudes_sprite_list.sort(key=lambda s: sum(s.position), reverse=True)
 
-    def show_path(self, current: tuple[Node]):
-        head = (0,)
-        body = tuple(range(1, len(current) - 1))
-        tail = (19,)
-        rest = range(len(current) - 1, 19)
+        self.refresh_draw_order()
 
-        visible = [*head, *body, *tail]
-        invisible = rest
-
-        for i, sprite in enumerate(self.selected_path_sprites):
-            if i in visible:
-                node_idx = i if i in head + body else -1
-                node = current[node_idx]
-                position = self.to_screen(node)
-                sprite.visible = True
-                sprite.center_x, sprite.center_y = position.x, position.y
-            elif i in invisible:
-                sprite.visible = False
-
-    def hide_path(self):
-        for sprite in self.selected_path_sprites:
-            sprite.visible = False
+    def teardown_level(self):
+        self.dudes_sprite_list.clear()
+        self.world_sprite_list.clear()
 
     def idle_or_attack(self, event):
         dude = event["attack"]
@@ -1005,7 +1031,5 @@ class CombatGridSection(arcade.Section):
         """
         If a sprite is associated to a dead entity, remove the sprite from the sprite list.
         """
-        dead_dude = event["dead"]
-        self.dudes_sprite_list.pop(
-            self.dudes_sprite_list.index(dead_dude.owner.entity_sprite.sprite)
-        )
+        dead_dude: Entity = event.get("dying") or event.get("retreat")
+        dead_dude.entity_sprite.sprite.remove_from_sprite_lists()

--- a/src/world/level/room.py
+++ b/src/world/level/room.py
@@ -1,7 +1,12 @@
+import random
 from functools import lru_cache
 
 from src.world.isometry.transforms import draw_priority
 from src.world.node import Node
+
+
+def rectangle(w: int = 1, h: int = 1, offset: Node = Node(0, 0)) -> tuple[Node, ...]:
+    return tuple(Node(x, y) + offset for x in range(w) for y in range(h))
 
 
 @lru_cache(maxsize=1)
@@ -24,14 +29,83 @@ def basic_room(dimensions: tuple[int, int], height: int = 0) -> tuple[Node, ...]
 
 
 @lru_cache(maxsize=1)
-def boss_room(dimensions: tuple[int, int], height: int = 0) -> tuple[Node, ...]:
+def side_pillars(dimensions: tuple[int, int], height: int = 0) -> tuple[Node, ...]:
     min_width = 5
     room = basic_room(dimensions, height)
     if min(dimensions[0], dimensions[1]) < min_width:
         return room
 
+    w, h = dimensions
+    pillars = [Node(x, y) for x in range(1, w, 2) for y in (1, h - 2)]
+
+    return tuple(sorted(pillars + list(room), key=draw_priority))
+
+
+@lru_cache(maxsize=1)
+def alternating_big_pillars(
+    dimensions: tuple[int, int], height: int = 0
+) -> tuple[Node, ...]:
+    min_width = 10
+    room = basic_room(dimensions, height)
+    if min(dimensions[0], dimensions[1]) < min_width:
+        return room
+
     pillars = [
-        Node(x, y) for x in range(1, dimensions[0], 2) for y in (1, dimensions[0] - 2)
+        *rectangle(2, 2, offset=Node(4, 1)),
+        *rectangle(2, 2, offset=Node(4, 7)),
+        *rectangle(2, 2, offset=Node(1, 4)),
+        *rectangle(2, 2, offset=Node(7, 4)),
     ]
 
     return tuple(sorted(pillars + list(room), key=draw_priority))
+
+
+@lru_cache(maxsize=1)
+def one_big_pillar(dimensions: tuple[int, int], height: int = 0) -> tuple[Node, ...]:
+    min_width = 10
+    room = basic_room(dimensions, height)
+    if min(dimensions[0], dimensions[1]) < min_width:
+        return room
+
+    pillars = [
+        *rectangle(4, 4, offset=Node(3, 3)),
+    ]
+
+    return tuple(sorted(pillars + list(room), key=draw_priority))
+
+
+@lru_cache(maxsize=1)
+def one_block_corridor(
+    dimensions: tuple[int, int], height: int = 0
+) -> tuple[Node, ...]:
+    """
+    Used as a stress test for congested pathing scenarios,
+    not included in random room
+    Args:
+        dimensions:
+        height:
+
+    Returns:
+
+    """
+    min_width = 10
+    room = basic_room(dimensions, height)
+    if min(dimensions[0], dimensions[1]) < min_width:
+        return room
+
+    pillars = [
+        *rectangle(10, 4, offset=Node(0, 0)),
+        *rectangle(10, 4, offset=Node(0, 6)),
+    ]
+
+    return tuple(sorted(pillars + list(room), key=draw_priority))
+
+
+def random_room(dimensions: tuple[int, int], height: int = 0) -> tuple[Node]:
+    return random.choice(
+        [
+            basic_room,
+            side_pillars,
+            alternating_big_pillars,
+        ]
+    )(dimensions, height)


### PR DESCRIPTION
 - Extended the `BaseSprite` implementation so that client code can set the transform on initialisation
 - Added a `set_node` method to the `BaseSprite` that will use the transform to set the appropriate sprite position
 - Fixed a bug where sprites of incapacitated fighters were not removed
 - Fixed a crash when no paths are available to a player character in combat, the turn is now forfeit.
 - Added new room layouts to dungeon generation.