### PR TITLE
Update MoveAction:

### DIFF
--- a/src/engine/persistence/loaders.py
+++ b/src/engine/persistence/loaders.py
@@ -78,9 +78,7 @@ class GameStateLoaders:
             "owner": owner,
             "health": cls.health_pool_from_dict(serialised_fighter.get("health")),
             "stats": FighterStats(**serialised_fighter.get("stats")),
-            "gear": cls.gear_from_dict(
-                serialised_fighter.get("gear"), owner=instance
-            ),
+            "gear": cls.gear_from_dict(serialised_fighter.get("gear"), owner=instance),
             "action_points": cls.action_points_from_dict(
                 serialised_fighter.get("action_points")
             ),

--- a/src/entities/action/actions.py
+++ b/src/entities/action/actions.py
@@ -102,7 +102,6 @@ class MoveAction(BaseAction, metaclass=ActionMeta):
 
     @classmethod
     def details(cls, fighter: Fighter, destination: Node, path) -> dict:
-        # path = fighter.locatable.path_to_destination(destination)
         return {
             **ActionMeta.details(cls, fighter, destination),
             "subject": fighter,
@@ -114,13 +113,12 @@ class MoveAction(BaseAction, metaclass=ActionMeta):
 
     @classmethod
     def all_available_to(cls, fighter: Fighter) -> list[dict]:
-        nearest_enemy = fighter.locatable.nearest_entity(
+        _, path = fighter.locatable.nearest_entity(
             room=fighter.encounter_context.get(),
             entity_filter=lambda e: e.fighter.is_enemy_of(fighter),
         )
 
-        full_path = fighter.locatable.path_to_target(nearest_enemy.fighter.locatable)
-        trimmed_path = full_path[: int(fighter.modifiable_stats.current.speed) + 1]
+        trimmed_path = path[: int(fighter.modifiable_stats.current.speed) + 1]
         destination = trimmed_path[-1]
 
         if destination in [
@@ -128,6 +126,7 @@ class MoveAction(BaseAction, metaclass=ActionMeta):
             for entity in fighter.encounter_context.encounter_context.occupants
         ]:
             destination = trimmed_path[-2]
+
         return [cls.details(fighter, destination, trimmed_path)]
 
     def __init__(self, fighter: Fighter, destination: Node) -> None:

--- a/src/entities/ai/basic_combat_ai.py
+++ b/src/entities/ai/basic_combat_ai.py
@@ -66,14 +66,14 @@ class ApproachingTarget(CombatAiState):
             max_range=fighter.gear.weapon._range,
             entity_filter=lambda e: e.fighter.is_enemy_of(fighter),
         )
-        
+
         path = self.working_set["path_to_nearest"]
         trimmed_path = path[: int(moves["subject"].modifiable_stats.current.speed) + 1]
 
         destination = trimmed_path[-1]
         if destination not in moves["subject"].encounter_context.get().space:
             destination = trimmed_path[-2]
-        
+
         if enemies_in_range:
             self.working_set["in_range"] = enemies_in_range
             return ChoosingAttack(self.working_set)

--- a/src/entities/ai/basic_combat_ai.py
+++ b/src/entities/ai/basic_combat_ai.py
@@ -59,7 +59,7 @@ class ApproachingTarget(CombatAiState):
 
     def next_state(self) -> State | None:
         target: Fighter = self.working_set["target"]
-        moves = self.choices_of(MoveAction)
+        moves = self.choices_of(MoveAction).pop()
         fighter = self.agent()
         enemies_in_range = fighter.locatable.entities_in_range(
             room=fighter.encounter_context.get(),
@@ -67,21 +67,11 @@ class ApproachingTarget(CombatAiState):
             entity_filter=lambda e: e.fighter.is_enemy_of(fighter),
         )
 
-        def ends_closest(option) -> int:
-            _path = option["subject"]
-
-            if target.locatable.path_to_destination(_path[-1]) is None:
-                return 1000
-
-            return len(target.locatable.path_to_destination(_path[-1]))
-
-        ranked_moves = sorted(moves, key=ends_closest)
-        best = ranked_moves[0]
         if enemies_in_range:
             self.working_set["in_range"] = enemies_in_range
             return ChoosingAttack(self.working_set)
         else:
-            self.working_set["output"] = best["on_confirm"]
+            self.working_set["output"] = moves["on_confirm"]
             return ActionChosen(self.working_set)
 
 

--- a/src/entities/ai/basic_combat_ai.py
+++ b/src/entities/ai/basic_combat_ai.py
@@ -34,7 +34,7 @@ class ChoosingTarget(CombatAiState):
         if fighter is None:
             raise ValueError(f"{self.working_set=}")
 
-        nearest = fighter.locatable.nearest_entity(
+        nearest, _ = fighter.locatable.nearest_entity(
             room=fighter.encounter_context.get(),
             entity_filter=lambda e: e.fighter.is_enemy_of(fighter),
         )

--- a/src/entities/gear/equippable_item.py
+++ b/src/entities/gear/equippable_item.py
@@ -110,6 +110,7 @@ class EquippableItem(EquippableABC):
         return self._attack_verb
 
     def dice(self, die_count: int, faces: int) -> int:
+        breakpoint()
         roll = 0
         for _ in range(die_count):
             roll += random.randint(1, faces)
@@ -117,7 +118,7 @@ class EquippableItem(EquippableABC):
 
     def emit_damage(self) -> Damage:
         dies = int(self.stats.attack_dice)
-        faces = self.stats.attack_dice_faces
+        faces = int(self.stats.attack_dice_faces)
         roll_base_damage = self.dice(dies, faces)
         max_damage = self._owner.modifiable_stats.current.power + roll_base_damage
 

--- a/src/entities/gear/equippable_item.py
+++ b/src/entities/gear/equippable_item.py
@@ -110,7 +110,6 @@ class EquippableItem(EquippableABC):
         return self._attack_verb
 
     def dice(self, die_count: int, faces: int) -> int:
-        breakpoint()
         roll = 0
         for _ in range(die_count):
             roll += random.randint(1, faces)

--- a/src/entities/properties/locatable.py
+++ b/src/entities/properties/locatable.py
@@ -49,32 +49,6 @@ class Locatable:
             }
         }
 
-    def approach_target(self, target: Locatable) -> Generator[dict]:
-        yield {
-            "message": f"{self.owner.name.name_and_title} moved toward {target.owner.name.name_and_title} with bad intentions"
-        }
-        if self.location == target.location:
-            # attacker and target are overlapping.
-            yield self.traverse(choice(self.adjacent_locations())),
-
-        target_adjancencies = set(target.locatable.adjacent_locations())
-
-        if self.location in target_adjancencies:
-            # no traversal is necessary
-            yield self._no_move()
-            return
-
-        # path ends in adjacent node to target
-        path_to_target = self.path_to_target(target)
-        dest_index = -1
-
-        for i, place in enumerate(path_to_target):
-            if place in target_adjancencies:
-                dest_index = i
-                break
-
-        yield from self.traverse(path_to_target[: dest_index + 1])
-
     def traverse(self, path: Sequence[Node]) -> Generator[dict]:
         if not path or len(path) == 1:
             yield self._no_move()
@@ -102,19 +76,6 @@ class Locatable:
                 "orientation": self.orientation,
             },
         }
-
-    def available_moves(self, speed: int | None = None) -> tuple[tuple[Node, ...], ...]:
-        paths = []
-        for node in self.space.all_included_nodes():
-            path = self.path_to_destination(node)
-            if path is None or len(path) <= 1:
-                continue
-            if len(path) > speed + 1:
-                continue
-
-            paths.append(path)
-
-        return tuple(paths)
 
     def adjacent_locations(self) -> tuple[Node, ...]:
         """A getter for the tuple of nodes that are close enough to this Locatable for

--- a/src/entities/properties/locatable.py
+++ b/src/entities/properties/locatable.py
@@ -215,4 +215,4 @@ class Locatable:
                 shortest_path = path
                 closest_entity = occupant
 
-        return closest_entity
+        return (closest_entity, shortest_path)

--- a/src/entities/properties/locatable.py
+++ b/src/entities/properties/locatable.py
@@ -166,6 +166,7 @@ class Locatable:
                 # calculation of paths for entities that we can't or shouldn't check
                 not occupant.locatable
                 or occupant.locatable is self
+                or not entity_filter(occupant)
             ):
                 continue
 
@@ -176,7 +177,7 @@ class Locatable:
             path_length = len(path)
             is_in_range = path_length - (max_range + 1) <= 0
 
-            if is_in_range and entity_filter(occupant):
+            if is_in_range:
                 in_range.append(occupant)
 
         return in_range

--- a/src/gui/combat/combat_menu.py
+++ b/src/gui/combat/combat_menu.py
@@ -185,25 +185,18 @@ class CombatMenu:
         agent: Fighter = available_moves[0]["subject"]
 
         def choose_move(node: Node):
-            callback = lambda: agent.ready_action(MoveAction(agent, get_current_node()))
+            callback = lambda: agent.ready_action(MoveAction(agent, node))
             callback()
             self._on_teardown()
 
         def validate_move(node: Node) -> bool:
-            occupied = [
-                entity.fighter.location
-                for entity in agent.encounter_context.get().occupants
-            ]
-            if node not in occupied:
-                return True
-            else:
-                return False
+            return node in agent.encounter_context.get().space
 
         def show_path(node: Node) -> None:
             current = agent.locatable.path_to_destination(node)
             limit = agent.modifiable_stats.current.speed + 1
-            if len(current) > limit:
-                current = current[: int(limit)]
+            current = current[: min(int(limit), len(current))]
+
             self._highlight(
                 green=current[:1],
                 gold=current[1:-1],

--- a/src/gui/guild/home.py
+++ b/src/gui/guild/home.py
@@ -207,8 +207,6 @@ class HomeView(arcade.View):
                 eng.game_state.set_guild(guild)
                 eng.game_state.set_team()
 
-                breakpoint()
-
             case arcade.key.G:
                 self.window.show_view(self.parent_factory())
 

--- a/src/tests/ai_fixture.py
+++ b/src/tests/ai_fixture.py
@@ -67,7 +67,7 @@ class TestAI:
         return in_range
 
     def fallback_move_decision(self, options: list[dict]):
-        nearest_enemy = self._current_fighter.locatable.nearest_entity(
+        nearest_enemy, _ = self._current_fighter.locatable.nearest_entity(
             self._current_fighter.encounter_context.get(),
             entity_filter=lambda e: self._current_fighter.is_enemy_of(e.fighter),
         )

--- a/src/tests/ai_fixture.py
+++ b/src/tests/ai_fixture.py
@@ -73,7 +73,7 @@ class TestAI:
     def destination(self, event):
         # breakpoint()
         fighter = event["choices"]["move"][0]["subject"]
-        
+
         _, path = fighter.locatable.nearest_entity(
             room=fighter.encounter_context.get(),
             entity_filter=lambda e: e.fighter.is_enemy_of(fighter),
@@ -87,9 +87,9 @@ class TestAI:
             for entity in fighter.encounter_context.encounter_context.occupants
         ]:
             destination = trimmed_path[-2]
-            
+
         return destination
-    
+
     def fallback_move_decision(self, options: list[dict]):
         nearest_enemy, _ = self._current_fighter.locatable.nearest_entity(
             self._current_fighter.encounter_context.get(),

--- a/src/tests/entities/test_actions.py
+++ b/src/tests/entities/test_actions.py
@@ -181,7 +181,7 @@ class MoveActionTest(unittest.TestCase):
                 "label",
             },
         )
-        
+
         # this has to be calculated now, if we get it later the fighter has reached their destination and
         # incurred the cost
         _, path = current_fighter.locatable.nearest_entity(
@@ -193,10 +193,8 @@ class MoveActionTest(unittest.TestCase):
         destination = trimmed_path[-1]
         if destination not in current_fighter.encounter_context.get().space:
             destination = trimmed_path[-2]
-        
-        cost = MoveAction.cost(
-            fighter=current_fighter, destination=destination
-        )
+
+        cost, _ = MoveAction.cost(fighter=current_fighter, destination=destination)
         expected_points_remaining = current_fighter.action_points.per_turn - cost
 
         # assert the turn generator gives us a series of moves

--- a/src/tests/entities/test_actions.py
+++ b/src/tests/entities/test_actions.py
@@ -172,18 +172,27 @@ class MoveActionTest(unittest.TestCase):
         decision = ai.latest_decision()
         _assert_keys(
             msg=decision,
-            expected_keys={"name", "actor", "cost", "subject", "on_confirm", "label"},
+            expected_keys={
+                "name",
+                "actor",
+                "cost",
+                "subject",
+                "destination",
+                "path",
+                "on_confirm",
+                "label",
+            },
         )
 
         # this has to be calculated now, if we get it later the fighter has reached their destination and
         # incurred the cost
         cost = MoveAction.cost(
-            fighter=current_fighter, destination=decision["subject"][-1]
+            fighter=current_fighter, destination=decision["destination"]
         )
         expected_points_remaining = current_fighter.action_points.per_turn - cost
 
         # assert the turn generator gives us a series of moves
-        chosen_path = decision["subject"]
+        chosen_path = decision["path"]
         step_event: dict | None = None
         for _ in range(len(chosen_path[1:])):
             step_event = next(turn)

--- a/src/tests/entities/test_actions.py
+++ b/src/tests/entities/test_actions.py
@@ -177,24 +177,32 @@ class MoveActionTest(unittest.TestCase):
                 "actor",
                 "cost",
                 "subject",
-                "destination",
-                "path",
                 "on_confirm",
                 "label",
             },
         )
-
+        
         # this has to be calculated now, if we get it later the fighter has reached their destination and
         # incurred the cost
+        _, path = current_fighter.locatable.nearest_entity(
+            room=current_fighter.encounter_context.get(),
+            entity_filter=lambda e: e.fighter.is_enemy_of(current_fighter),
+        )
+
+        trimmed_path = path[: int(current_fighter.modifiable_stats.current.speed) + 1]
+        destination = trimmed_path[-1]
+        if destination not in current_fighter.encounter_context.get().space:
+            destination = trimmed_path[-2]
+        
         cost = MoveAction.cost(
-            fighter=current_fighter, destination=decision["destination"]
+            fighter=current_fighter, destination=destination
         )
         expected_points_remaining = current_fighter.action_points.per_turn - cost
 
         # assert the turn generator gives us a series of moves
-        chosen_path = decision["path"]
+        # chosen_path = decision["path"]
         step_event: dict | None = None
-        for _ in range(len(chosen_path[1:])):
+        for _ in range(len(trimmed_path[1:])):
             step_event = next(turn)
             _assert_keys(msg=step_event, expected_keys={"move"})
 

--- a/src/tests/systems/test_combat_round.py
+++ b/src/tests/systems/test_combat_round.py
@@ -86,6 +86,7 @@ class CombatRoundTest(TestCase):
                 assert (
                     not combat_round.continues()
                 ), "Combat should not be continuing now"
-                assert (
-                    combat_round and combat_round.victor() is not None
-                ), "No clear winner, seems sus."
+            
+            assert (
+                combat_round and combat_round.victor() is not None
+            ), "No clear winner, seems sus."

--- a/src/tests/systems/test_combat_round.py
+++ b/src/tests/systems/test_combat_round.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from viztracer import VizTracer
+
 from src.entities.ai.ai import BasicCombatAi
 from src.entities.combat.fighter import Fighter
 from src.entities.entity import Entity, Name
@@ -64,23 +66,24 @@ class CombatRoundTest(TestCase):
 
         # Action
         # ======
-        while not merc.fighter.incapacitated and not enemy.fighter.incapacitated:
-            combat_round = CombatRound([merc], [enemy])
-            while combat_round.continues():
-                for event in combat_round.do_turn():
-                    # auto select first target
-                    if "await_input" in event:
-                        fighter = event["await_input"]
-                        ai.choose(event)
-                        assert fighter.is_ready_to_act()
+        with VizTracer(output_file="profiles/combat_round_profile.json"):
+            while not merc.fighter.incapacitated and not enemy.fighter.incapacitated:
+                combat_round = CombatRound([merc], [enemy])
+                while combat_round.continues():
+                    for event in combat_round.do_turn():
+                        # auto select first target
+                        if "await_input" in event:
+                            fighter = event["await_input"]
+                            ai.choose(event)
+                            assert fighter.is_ready_to_act()
 
-            # assert we're actually progressing the state
-            assert (
-                rounds < max_rounds
-            ), f"hit max rounds. Locations: {merc.locatable.location=}, {enemy.locatable.location=}"
-            rounds += 1
+                # assert we're actually progressing the state
+                assert (
+                    rounds < max_rounds
+                ), f"hit max rounds. Locations: {merc.locatable.location=}, {enemy.locatable.location=}"
+                rounds += 1
 
-            assert not combat_round.continues(), "Combat should not be continuing now"
-            assert (
-                combat_round and combat_round.victor() is not None
-            ), "No clear winner, seems sus."
+                assert not combat_round.continues(), "Combat should not be continuing now"
+                assert (
+                    combat_round and combat_round.victor() is not None
+                ), "No clear winner, seems sus."

--- a/src/tests/systems/test_combat_round.py
+++ b/src/tests/systems/test_combat_round.py
@@ -83,7 +83,9 @@ class CombatRoundTest(TestCase):
                 ), f"hit max rounds. Locations: {merc.locatable.location=}, {enemy.locatable.location=}"
                 rounds += 1
 
-                assert not combat_round.continues(), "Combat should not be continuing now"
+                assert (
+                    not combat_round.continues()
+                ), "Combat should not be continuing now"
                 assert (
                     combat_round and combat_round.victor() is not None
                 ), "No clear winner, seems sus."


### PR DESCRIPTION
- MoveAction no longer searches the entire pathing space to generate an array of possible moves.
- Instead, just get the path to the nearest entity, then trim that path to be limited by speed stat.
- MoveAction details now carries the Fighter as Subject, the destination, and the path.
- ApproachingTarget AI State just checks if a target has appeared in range to attack, otherwise moves.
- Move validation uses the encounter context carried by fighters to prevent final step overlapping another entity.
- Move templating for the player just calculates path to the current moused over node, limited by speed stat.
- Updated tests.