### PR TITLE
Equipment Icons

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def start_adventure_league():
     )
 
     window.set_icon(WindowData.window_icon)
-    window.set_minimum_size(1080, 720)
+    window.set_minimum_size(1600, 900)
     title_view = TitleView(window=window)
     window.show_view(title_view)
 

--- a/src/entities/combat/fighter.py
+++ b/src/entities/combat/fighter.py
@@ -22,7 +22,7 @@ from src.entities.item.inventory import Inventory
 from src.entities.item.inventory_item import Consumable
 from src.entities.magic.caster import Caster
 from src.entities.properties.meta_compendium import MetaCompendium
-from src.entities.sprites import SpriteAttribute
+from src.entities.sprites import AnimatedSpriteAttribute
 from src.world.node import Node
 from src.world.ray import Ray
 

--- a/src/entities/combat/stats.py
+++ b/src/entities/combat/stats.py
@@ -92,6 +92,24 @@ class EquippableItemStats(NamedTuple):
     def __sub__(self, other):
         return namedtuple_sub(self.__class__, self, other)
 
+    def display_stats(self, delim: str = " | ") -> str:
+        dict_val = self._asdict()
+
+        dmg_string = f"Attack: {self.attack_dice}d{self.attack_dice_faces}"
+        dict_val.pop("attack_dice")
+        dict_val.pop("attack_dice_faces")
+
+        attributes = [dmg_string]
+
+        for stat_name, value in dict_val.items():
+            readable_name = stat_name.replace("_", " ").title()
+            if isinstance(value, float):
+                value = f"{value:.1f}"
+            readable_stat = f"{readable_name}: {value}"
+            attributes.append(readable_stat)
+
+        return delim.join(attributes)
+
 
 class StatAffix(NamedTuple):
     name: str

--- a/src/entities/entity.py
+++ b/src/entities/entity.py
@@ -7,7 +7,7 @@ from src.entities.item.inventory import Inventory
 from src.entities.item.inventory_item import InventoryItem
 from src.entities.properties.locatable import Locatable
 from src.entities.sprite_assignment import Species, attach_sprites
-from src.entities.sprites import SpriteAttribute
+from src.entities.sprites import AnimatedSpriteAttribute
 from src.world.node import Node
 from src.world.pathing.pathing_space import PathingSpace
 
@@ -32,7 +32,7 @@ class Name(NamedTuple):
 
 
 class Entity:
-    entity_sprite: SpriteAttribute | None
+    entity_sprite: AnimatedSpriteAttribute | None
     fighter: Fighter | None
     inventory: Inventory | None
     ai: AiInterface | None
@@ -91,7 +91,7 @@ class Entity:
         self.inventory = Inventory(owner=self, capacity=capacity)
         return self
 
-    def set_entity_sprite(self, sprite: SpriteAttribute):
+    def set_entity_sprite(self, sprite: AnimatedSpriteAttribute):
         self.entity_sprite = sprite
         if self.entity_sprite:
             self.entity_sprite.owner = self

--- a/src/entities/gear/base_gear_names.py
+++ b/src/entities/gear/base_gear_names.py
@@ -1,0 +1,7 @@
+from typing import NamedTuple
+
+
+class BaseWeaponNames(NamedTuple):
+    SWORD = "sword"
+    BOW = "bow"
+    STAVE = "grimoire"

--- a/src/entities/gear/equippable_item.py
+++ b/src/entities/gear/equippable_item.py
@@ -10,7 +10,8 @@ from src.entities.combat.stats import EquippableItemStats, FighterStats, StatAff
 from src.entities.combat.weapon_attacks import WeaponAttackMeta
 from src.entities.magic.spells import Spell, SpellMeta
 from src.entities.properties.meta_compendium import MetaCompendium
-from src.entities.sprites import SpriteAttribute
+from src.entities.sprites import AnimatedSpriteAttribute, SimpleSpriteAttribute
+from src.gui.simple_sprite_config import choose_item_texture
 from src.textures.texture_data import SpriteSheetSpecs
 from src.utils.dice import D
 
@@ -52,7 +53,7 @@ class EquippableABC(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
 
-tex = SpriteSheetSpecs.icons.load_one(68)
+tex = SpriteSheetSpecs.icons.load_one(108)
 
 
 class EquippableItem(EquippableABC):
@@ -73,11 +74,6 @@ class EquippableItem(EquippableABC):
     ) -> None:
         self._owner = owner
 
-        self._sprite = SpriteAttribute(
-            idle_textures=(tex,), attack_textures=(tex,), scale=6
-        )
-        self._sprite.owner = self
-
         self._config = config
         self._slot = config.slot
         self._name = config.name
@@ -88,13 +84,18 @@ class EquippableItem(EquippableABC):
         self._fighter_affixes = config.fighter_affixes
         self._equippable_item_affixes = config.equippable_item_affixes
         self._stats = config.stats
+        self._sprite = SimpleSpriteAttribute(
+            path_or_texture=choose_item_texture(self), scale=6
+        )
+        self._sprite.owner = self
+
         self._modifiable_stats = ModifiableStats(EquippableItemStats, self._stats)
         self._available_attacks_cache = []
         self._available_spells_cache = []
         self._init_affixes()
 
     @property
-    def sprite(self) -> SpriteAttribute:
+    def sprite(self) -> AnimatedSpriteAttribute:
         return self._sprite
 
     @property

--- a/src/entities/gear/equippable_item.py
+++ b/src/entities/gear/equippable_item.py
@@ -4,6 +4,7 @@ import abc
 import random
 from typing import TYPE_CHECKING, NamedTuple, Self
 
+from src import config
 from src.entities.combat.damage import Damage
 from src.entities.combat.modifiable_stats import ModifiableStats, Modifier
 from src.entities.combat.stats import EquippableItemStats, FighterStats, StatAffix
@@ -93,6 +94,9 @@ class EquippableItem(EquippableABC):
         self._available_attacks_cache = []
         self._available_spells_cache = []
         self._init_affixes()
+
+    def display_stats(self, delim=" | "):
+        return self._stats.display_stats(delim)
 
     @property
     def sprite(self) -> AnimatedSpriteAttribute:

--- a/src/entities/gear/weapons.py
+++ b/src/entities/gear/weapons.py
@@ -1,4 +1,5 @@
 from typing import NamedTuple
+
 from src.entities.combat.stats import (
     EquippableItemStats,
     percent_crit_increase,
@@ -8,7 +9,6 @@ from src.entities.combat.weapon_attacks import NormalAttack
 from src.entities.gear.base_gear_names import BaseWeaponNames
 from src.entities.gear.equippable_item import EquippableItemConfig
 from src.entities.magic.spells import Fireball, MagicMissile, Shield
-
 
 sword = EquippableItemConfig(
     name=BaseWeaponNames.SWORD,

--- a/src/entities/gear/weapons.py
+++ b/src/entities/gear/weapons.py
@@ -1,14 +1,17 @@
+from typing import NamedTuple
 from src.entities.combat.stats import (
     EquippableItemStats,
     percent_crit_increase,
     raw_power_increase,
 )
 from src.entities.combat.weapon_attacks import NormalAttack
+from src.entities.gear.base_gear_names import BaseWeaponNames
 from src.entities.gear.equippable_item import EquippableItemConfig
 from src.entities.magic.spells import Fireball, MagicMissile, Shield
 
+
 sword = EquippableItemConfig(
-    name="sword",
+    name=BaseWeaponNames.SWORD,
     slot="_weapon",
     attack_verb="melee",
     range=1,
@@ -26,7 +29,7 @@ sword = EquippableItemConfig(
 )
 
 bow = EquippableItemConfig(
-    name="bow",
+    name=BaseWeaponNames.BOW,
     slot="_weapon",
     attack_verb="ranged",
     range=5,
@@ -42,7 +45,7 @@ bow = EquippableItemConfig(
 )
 
 spellbook = EquippableItemConfig(
-    name="grimoire",
+    name=BaseWeaponNames.STAVE,
     slot="_weapon",
     attack_verb="melee",
     range=1,

--- a/src/entities/sprite_assignment.py
+++ b/src/entities/sprite_assignment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Self
 
-from src.entities.sprites import SpriteAttribute
+from src.entities.sprites import AnimatedSpriteAttribute
 
 if TYPE_CHECKING:
     from src.entities.entity import Entity
@@ -59,7 +59,7 @@ def select_textures(species: str, fighter: Fighter) -> AnimatedSpriteConfig:
 def attach_sprites(entity: Entity) -> Entity:
     sprite_config = select_textures(entity.species, entity.fighter)
     entity.set_entity_sprite(
-        SpriteAttribute(
+        AnimatedSpriteAttribute(
             idle_textures=sprite_config.idle_textures,
             attack_textures=sprite_config.attack_textures,
         )

--- a/src/entities/sprites.py
+++ b/src/entities/sprites.py
@@ -131,7 +131,7 @@ class BaseSprite(OffsetSprite, Sprite):
                     self.animation_cycle = 0.75
 
 
-class SpriteAttribute:
+class AnimatedSpriteAttribute:
     sprite: BaseSprite
 
     def __init__(
@@ -194,3 +194,21 @@ class SpriteAttribute:
                 pass
 
         self.sprite.set_texture(0)
+
+
+class SimpleSpriteAttribute:
+    sprite: BaseSprite
+
+    def __init__(
+        self,
+        path_or_texture: Texture,
+        scale: float = 4,
+    ) -> None:
+        self.owner = None
+        self.sprite = BaseSprite(path_or_texture=path_or_texture, scale=scale)
+        self.sprite.owner = self
+        self.sprite.set_texture(0)
+
+    def offset_anchor(self, offset_px: Point) -> Self:
+        self.sprite.offset_anchor(offset_px)
+        return self

--- a/src/entities/sprites.py
+++ b/src/entities/sprites.py
@@ -94,6 +94,9 @@ class BaseSprite(OffsetSprite, Sprite):
         self._draw_priority_offset = kwargs.get("draw_priority_offset", 0)
         self._node = None
 
+    def set_scale(self, scale: int):
+        self.scale = scale
+
     def get_draw_priority(self) -> float:
         return self._draw_priority - self._draw_priority_offset
 

--- a/src/gui/components/draggables.py
+++ b/src/gui/components/draggables.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 import arcade
 from pyglet.math import Vec2
 
+from src.utils.rectangle import Rectangle
+
 if TYPE_CHECKING:
     from src.entities.gear.equippable_item import EquippableItem
     from src.entities.gear.gear import Gear
@@ -15,14 +17,28 @@ class Draggable:
     sprite: arcade.Sprite
     is_held: bool = False
     item: EquippableItem
+    hit_box: Rectangle
 
     def __init__(self, item: EquippableItem, is_held=False):
         self.sprite = item._sprite.sprite
         self.item = item
         self.is_held = is_held
 
+    @property
+    def hit_box(self) -> Rectangle:
+        return Rectangle.from_limits(
+            min_v=Vec2(
+                self.sprite.center_x - self.sprite.width / 2,
+                self.sprite.center_y - self.sprite.height / 2,
+            ),
+            max_v=Vec2(
+                self.sprite.center_x + self.sprite.width / 2,
+                self.sprite.center_y + self.sprite.height / 2,
+            ),
+        )
+
     def is_clicked(self, mouse: tuple[int, int]) -> bool:
-        return self.sprite.collides_with_point(mouse)
+        return Vec2(*mouse) in self.hit_box
 
     def reposition(self, new_pos: Vec2):
         self.sprite.position = new_pos
@@ -44,11 +60,11 @@ class DraggableCollection:
         self.hand = None
         self.original_position = None
 
-    def draggable_at_position(self, position: Vec2) -> Draggable | None:
+    def draggable_at_position(self, mouse_position: Vec2) -> Draggable | None:
         hovered_draggable = None
 
         for draggable in self.draggables:
-            if draggable.sprite.collides_with_point(position):
+            if mouse_position in draggable.hit_box:
                 hovered_draggable = draggable
                 break
 

--- a/src/gui/components/draggables.py
+++ b/src/gui/components/draggables.py
@@ -23,9 +23,10 @@ class Draggable:
 
     def is_clicked(self, mouse: tuple[int, int]) -> bool:
         return self.sprite.collides_with_point(mouse)
-    
+
     def reposition(self, new_pos: Vec2):
         self.sprite.position = new_pos
+
 
 class DraggableCollection:
     draggables: list[Draggable]
@@ -41,6 +42,17 @@ class DraggableCollection:
         self.prepare_draggables(gear)
 
         self.hand = None
+        self.original_position = None
+
+    def draggable_at_position(self, position: Vec2) -> Draggable | None:
+        hovered_draggable = None
+
+        for draggable in self.draggables:
+            if draggable.sprite.collides_with_point(position):
+                hovered_draggable = draggable
+                break
+
+        return hovered_draggable
 
     def prepare_draggables(self, gear: Gear):
         for item in gear.as_list():
@@ -54,13 +66,15 @@ class DraggableCollection:
             self.draggables.append(draggable)
             self.sprites.append(draggable.sprite)
 
-    def pick_up_at_mouse(self, mouse: tuple[int, int]):
+    def pick_up_at_mouse(self, mouse: tuple[int, int]) -> tuple[int, int] | None:
         for item in self.draggables:
             item.is_held = not self.hand and item.is_clicked(mouse)
             if item.is_held:
                 self.draggables.remove(item)
                 self.hand = item
-                return
+                return item.sprite.position
+
+        return None
 
     def on_update(self, lmb: bool):
         if self.hand and not lmb:

--- a/src/gui/components/draggables.py
+++ b/src/gui/components/draggables.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import arcade
+from pyglet.math import Vec2
 
 if TYPE_CHECKING:
     from src.entities.gear.equippable_item import EquippableItem
@@ -22,7 +23,9 @@ class Draggable:
 
     def is_clicked(self, mouse: tuple[int, int]) -> bool:
         return self.sprite.collides_with_point(mouse)
-
+    
+    def reposition(self, new_pos: Vec2):
+        self.sprite.position = new_pos
 
 class DraggableCollection:
     draggables: list[Draggable]

--- a/src/gui/components/draggables.py
+++ b/src/gui/components/draggables.py
@@ -60,6 +60,9 @@ class DraggableCollection:
         self.hand = None
         self.original_position = None
 
+    def rescale_sprite(self, scale):
+        self.hand.sprite.scale = scale
+    
     def draggable_at_position(self, mouse_position: Vec2) -> Draggable | None:
         hovered_draggable = None
 
@@ -88,6 +91,7 @@ class DraggableCollection:
             if item.is_held:
                 self.draggables.remove(item)
                 self.hand = item
+                self.rescale_sprite(12)
                 return item.sprite.position
 
         return None
@@ -98,6 +102,7 @@ class DraggableCollection:
 
     def drop(self):
         self.draggables.append(self.hand)
+        self.rescale_sprite(6)
         self.hand.is_held = False
         self.on_drop(self.hand)
         self.hand = None

--- a/src/gui/components/layouts.py
+++ b/src/gui/components/layouts.py
@@ -70,7 +70,7 @@ class ColoredLabel(NamedTuple):
         )
 
 
-def label_with_observer(
+def get_colored_label(
     label: Colored_Label,
     width,
     height,
@@ -79,7 +79,7 @@ def label_with_observer(
     color,
     attach,
     multiline,
-):
+) -> UILabel:
     return ColoredLabel(label, align, font_size, color, attach).get_ui_label(
         width=width, height=height, multiline=multiline
     )

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -6,11 +6,14 @@ import arcade
 
 from src.engine.armory import Armory
 from src.gui.components.draggables import Draggable
-from src.gui.guild.inventory_grid import SnapGrid
+from src.gui.guild.snap_grid import SnapGrid
+from src.textures.pixelated_nine_patch import PixelatedNinePatch
+from src.textures.texture_data import SingleTextureSpecs
+from src.utils.rectangle import Corner, Rectangle
 
 if TYPE_CHECKING:
     from src.entities.gear.equippable_item import EquippableItem
-    from src.gui.guild.inventory_grid import GridLoc
+    from src.gui.guild.snap_grid import GridLoc
     from src.entities.gear.gear import Gear
 
 from pyglet.math import Vec2
@@ -32,18 +35,18 @@ class ItemReceiver:
         self.sprite = sprite
         self.initial_overlay()
 
-    def put(self, item: EquippableItem) -> bool:
-        if not self.can_receive(item):
+    def put(self, draggable: Draggable) -> bool:
+        if not self.can_receive(draggable):
             return False
-        if not self.gear.is_equipped(item):
-            self.inventory_grid.take(item, remove_from_storage=True)
-            self.gear.equip_item(item, eng.game_state.guild.armory)
+        if not self.gear.is_equipped(draggable.item):
+            self.inventory_grid.take(draggable, remove_from_storage=True)
+            self.gear.equip_item(draggable.item, eng.game_state.guild.armory)
 
-        item._sprite.sprite.position = self.sprite.position
+        draggable.item._sprite.sprite.position = self.sprite.position
         return True
 
-    def can_receive(self, item) -> bool:
-        return item.slot == self.slot
+    def can_receive(self, draggable: Draggable) -> bool:
+        return draggable.item.slot == self.slot
 
     def initial_overlay(self):
         if self.slot == "_weapon" and self.gear.weapon:
@@ -53,8 +56,14 @@ class ItemReceiver:
         elif self.slot == "_body" and self.gear.body:
             self.gear.body._sprite.sprite.position = self.sprite.position
 
+    def reposition(self, new_pos: Vec2):
+        self.sprite.position = new_pos
+    
 
 class InventoryGrid:
+    _grid: SnapGrid
+    _contents: dict[GridLoc, Draggable]
+
     def __init__(
         self,
         w: int,
@@ -63,7 +72,7 @@ class InventoryGrid:
         storage: Armory,
         gear: Gear,
         bottom_left: Vec2 | None = None,
-        contents: dict[GridLoc, EquippableItem] | None = None,
+        contents: dict[GridLoc, Draggable] | None = None,
         original_draggable_position: Callable[[], tuple[float, float] | None]
         | None = None,
     ):
@@ -75,22 +84,42 @@ class InventoryGrid:
         self._storage = storage
         self._gear = gear
         self.original_draggable_position = original_draggable_position
+        self._pin_args = None
+        self._receivers = []
+        self._draggables = []
 
-    def search_contents(self, item) -> GridLoc | None:
+    def get_bounds(self) -> Rectangle:
+        return self._grid.bounds
+
+    def search_contents(self, draggable: Draggable) -> GridLoc | None:
         for loc, candidate in self._contents.items():
-            if item is candidate:
+            if draggable.item is candidate.item:
                 return loc
 
         return None
+    
+    def pin_corner(self, corner: Corner, pin: Callable[[], Vec2]):
+        self._grid.pin_corner(corner, pin)
 
-    def take(self, item: EquippableItem, remove_from_storage: bool = False):
-        loc = self.search_contents(item)
+    def on_resize(self):
+        self._grid.on_resize()
+
+        for receiver, screen_pos in zip(self._receivers, self._grid.locations_in_rows()):
+            grid_loc = self._grid.to_grid_loc(screen_pos)
+            if occupying_draggable := self._contents.get(grid_loc):
+                occupying_draggable.reposition(screen_pos)
+            receiver.reposition(screen_pos)
+
+    def take(self, draggable: Draggable, remove_from_storage: bool = False):
+        item = draggable.item
+        loc = self.search_contents(draggable)
         if loc:
             self._contents.pop(loc)
         if item in self._storage and remove_from_storage:
             self._storage.remove(item)
 
-    def put(self, item: EquippableItem):
+    def put(self, draggable: Draggable):
+        item = draggable.item
         screen_pos = Vec2(*item.sprite.sprite.position)
 
         snapped = self._grid.snap_to_grid(screen_pos)
@@ -101,18 +130,20 @@ class InventoryGrid:
         item.sprite.sprite.position = snapped
 
         if item in self._storage.storage:
-            self.take(item)
+            self.take(draggable)
         elif self._gear.is_equipped(item):
             self._gear.unequip(item.slot, self._storage)
 
-        self._contents[self._grid.to_grid_loc(screen_pos)] = item
+        self._contents[self._grid.to_grid_loc(screen_pos)] = draggable
 
     def build_receivers(self) -> list[StorageReceiver]:
-        receivers = []
+        if self._receivers:
+            return [*self._receivers]
+        
         for screen_pos in self._grid.locations_in_rows():
-            receivers.append(self._build_receiver(screen_pos))
+            self._receivers.append(self._build_receiver(screen_pos))
 
-        return receivers
+        return [*self._receivers]
 
     def _build_receiver(self, screen_pos: Vec2) -> StorageReceiver:
         return StorageReceiver(
@@ -135,9 +166,10 @@ class InventoryGrid:
                 continue
 
             item = storage[placed]
-            draggables.append(self._build_draggable(screen_pos, storage[placed]))
+            draggable = self._build_draggable(screen_pos, storage[placed])
+            draggables.append(draggable)
             placed += 1
-            self._contents[self._grid.to_grid_loc(screen_pos)] = item
+            self._contents[self._grid.to_grid_loc(screen_pos)] = draggable
             item.sprite.sprite.position = screen_pos
 
         return draggables
@@ -156,16 +188,18 @@ class StorageReceiver:
         self.sprite = sprite
         self.inventory_grid = inventory
 
-    def put(self, item: EquippableItem) -> bool:
-        if not self.can_receive(item):
+    def put(self, draggable: Draggable) -> bool:
+        if not self.can_receive(draggable):
             return False
 
-        self.inventory_grid.put(item)
+        self.inventory_grid.put(draggable)
         return True
 
-    def can_receive(self, item: EquippableItem) -> bool:
-        return not self.inventory_grid.is_occupied(Vec2(*item.sprite.sprite.position))
+    def can_receive(self, draggable: Draggable) -> bool:
+        return not self.inventory_grid.is_occupied(Vec2(*draggable.item.sprite.sprite.position))
 
+    def reposition(self, new_pos: Vec2):
+        self.sprite.position = new_pos
 
 class ReceiverCollection:
     _item_receivers: dict[str, ItemReceiver]
@@ -204,7 +238,7 @@ class ReceiverCollection:
         return None
 
     def put_into_slot_at_sprite(
-        self, sprite: arcade.Sprite, item: EquippableItem
+        self, sprite: arcade.Sprite, draggable: Draggable
     ) -> bool:
         slot = self.identify_equip_slot(sprite)
         if not slot:
@@ -216,6 +250,6 @@ class ReceiverCollection:
         match slot:
             case x if isinstance(x, str):
                 if receiver := self._item_receivers.get(slot, None):
-                    return receiver.put(item)
+                    return receiver.put(draggable)
             case x if isinstance(x, int):
-                return self._storage_receivers[slot].put(item)
+                return self._storage_receivers[slot].put(draggable)

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Callable
 import arcade
 
 from src.engine.armory import Armory
-from src.gui.components.draggables import Draggable
+from src.gui.components.draggables import Draggable, DraggableCollection
 from src.gui.guild.snap_grid import SnapGrid
 from src.textures.pixelated_nine_patch import PixelatedNinePatch
 from src.textures.texture_data import SingleTextureSpecs
@@ -211,7 +211,7 @@ class InventoryGrid:
         return draggables
 
     def _build_draggable(self, screen_pos: Vec2, item: EquippableItem) -> Draggable:
-        item.sprite.position = screen_pos.x, screen_pos.y
+        item.sprite.position = int(screen_pos.x), int(screen_pos.y)
         return Draggable(item)
 
     def is_occupied(self, screen_pos: Vec2) -> bool:

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -36,7 +36,7 @@ class ItemReceiver:
         if not self.can_receive(item):
             return False
         if not self.gear.is_equipped(item):
-            self.inventory_grid.take(item)
+            self.inventory_grid.take(item, remove_from_storage=True)
             self.gear.equip_item(item, eng.game_state.guild.armory)
 
         item._sprite.sprite.position = self.sprite.position
@@ -83,11 +83,11 @@ class InventoryGrid:
 
         return None
 
-    def take(self, item: EquippableItem):
+    def take(self, item: EquippableItem, remove_from_storage: bool = False):
         loc = self.search_contents(item)
         if loc:
             self._contents.pop(loc)
-        if item in self._storage:
+        if item in self._storage and remove_from_storage:
             self._storage.remove(item)
 
     def put(self, item: EquippableItem):
@@ -101,7 +101,7 @@ class InventoryGrid:
         item.sprite.sprite.position = snapped
 
         if item in self._storage.storage:
-            return
+            self.take(item)
         elif self._gear.is_equipped(item):
             self._gear.unequip(item.slot, self._storage)
 

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -73,10 +73,11 @@ class InventoryGrid:
         storage: Armory,
         gear: Gear,
         bottom_left: Vec2 | None = None,
+        top_left: Vec2 | None = None,
         contents: dict[GridLoc, Draggable] | None = None,
     ):
         self._grid = SnapGrid.from_grid_dimensions(
-            w, h, slot_size, bottom_left or Vec2(0, 0)
+            w, h, slot_size, bottom_left or Vec2(0, 0), top_left or Vec2(0,0)
         )
         self._sprite_dims = slot_size * 0.9
         self._contents = contents or {}

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -100,10 +100,10 @@ class InventoryGrid:
 
         item.sprite.sprite.position = snapped
 
-        if self._gear.is_equipped(item):
+        if item in self._storage.storage:
+            return
+        elif self._gear.is_equipped(item):
             self._gear.unequip(item.slot, self._storage)
-        else:
-            self.take(item)
 
         self._contents[self._grid.to_grid_loc(screen_pos)] = item
 

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -58,7 +58,7 @@ class ItemReceiver:
 
     def reposition(self, new_pos: Vec2):
         self.sprite.position = new_pos
-    
+
 
 class InventoryGrid:
     _grid: SnapGrid
@@ -73,8 +73,6 @@ class InventoryGrid:
         gear: Gear,
         bottom_left: Vec2 | None = None,
         contents: dict[GridLoc, Draggable] | None = None,
-        original_draggable_position: Callable[[], tuple[float, float] | None]
-        | None = None,
     ):
         self._grid = SnapGrid.from_grid_dimensions(
             w, h, slot_size, bottom_left or Vec2(0, 0)
@@ -83,7 +81,6 @@ class InventoryGrid:
         self._contents = contents or {}
         self._storage = storage
         self._gear = gear
-        self.original_draggable_position = original_draggable_position
         self._pin_args = None
         self._receivers = []
         self._draggables = []
@@ -97,14 +94,16 @@ class InventoryGrid:
                 return loc
 
         return None
-    
+
     def pin_corner(self, corner: Corner, pin: Callable[[], Vec2]):
         self._grid.pin_corner(corner, pin)
 
     def on_resize(self):
         self._grid.on_resize()
 
-        for receiver, screen_pos in zip(self._receivers, self._grid.locations_in_rows()):
+        for receiver, screen_pos in zip(
+            self._receivers, self._grid.locations_in_rows()
+        ):
             grid_loc = self._grid.to_grid_loc(screen_pos)
             if occupying_draggable := self._contents.get(grid_loc):
                 occupying_draggable.reposition(screen_pos)
@@ -124,7 +123,6 @@ class InventoryGrid:
 
         snapped = self._grid.snap_to_grid(screen_pos)
         if snapped is None:
-            item.sprite.sprite.position = self.original_draggable_position()
             return
 
         item.sprite.sprite.position = snapped
@@ -139,7 +137,7 @@ class InventoryGrid:
     def build_receivers(self) -> list[StorageReceiver]:
         if self._receivers:
             return [*self._receivers]
-        
+
         for screen_pos in self._grid.locations_in_rows():
             self._receivers.append(self._build_receiver(screen_pos))
 
@@ -196,10 +194,13 @@ class StorageReceiver:
         return True
 
     def can_receive(self, draggable: Draggable) -> bool:
-        return not self.inventory_grid.is_occupied(Vec2(*draggable.item.sprite.sprite.position))
+        return not self.inventory_grid.is_occupied(
+            Vec2(*draggable.item.sprite.sprite.position)
+        )
 
     def reposition(self, new_pos: Vec2):
         self.sprite.position = new_pos
+
 
 class ReceiverCollection:
     _item_receivers: dict[str, ItemReceiver]

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -33,7 +33,44 @@ class ItemReceiver:
         self.gear = gear
         self.slot = slot
         self.sprite = sprite
+
+        self.bounds = Rectangle.from_limits(
+            min_v=Vec2(
+                self.sprite.center_x - self.sprite.width / 2,
+                self.sprite.center_y - self.sprite.height / 2,
+            ),
+            max_v=Vec2(
+                self.sprite.center_x + self.sprite.width / 2,
+                self.sprite.center_y + self.sprite.height / 2,
+            ),
+        )
+        self._pin, self._corner = None, None
+        self.pin_corner(Corner.TOP_LEFT, self.get_offsets())
+
         self.initial_overlay()
+
+    def get_offsets(self) -> Callable[[], Vec2]:
+        y_offset = (
+            arcade.get_window().height - self.sprite.center_y - self.sprite.height / 2
+        )
+        x_offset = (
+            arcade.get_window().width - self.sprite.center_x + self.sprite.width / 2
+        )
+
+        return lambda: Vec2(
+            arcade.get_window().width - x_offset, arcade.get_window().height - y_offset
+        )
+
+    def pin_corner(self, corner: Corner, pin: Callable[[], Vec2]):
+        self._pin = pin
+        self._corner = corner
+
+    def on_resize(self):
+        if not self._corner or not self._pin:
+            return
+
+        self.bounds = self.bounds.with_corner_at(self._corner, self._pin())
+        self.sprite.position = self.bounds.center
 
     def put(self, draggable: Draggable) -> bool:
         if not self.can_receive(draggable):

--- a/src/gui/components/receivers.py
+++ b/src/gui/components/receivers.py
@@ -47,7 +47,7 @@ class ItemReceiver:
         self._pin, self._corner = None, None
         self.pin_corner(Corner.TOP_LEFT, self.get_offsets())
 
-        self.initial_overlay()
+        self.overlay_equipped_sprite()
 
     def get_offsets(self) -> Callable[[], Vec2]:
         y_offset = (
@@ -70,8 +70,9 @@ class ItemReceiver:
             return
 
         self.bounds = self.bounds.with_corner_at(self._corner, self._pin())
-        self.sprite.position = self.bounds.center
-
+        self.reposition(self.bounds.center)
+        self.overlay_equipped_sprite()
+        
     def put(self, draggable: Draggable) -> bool:
         if not self.can_receive(draggable):
             return False
@@ -85,7 +86,7 @@ class ItemReceiver:
     def can_receive(self, draggable: Draggable) -> bool:
         return draggable.item.slot == self.slot
 
-    def initial_overlay(self):
+    def overlay_equipped_sprite(self):
         if self.slot == "_weapon" and self.gear.weapon:
             self.gear.weapon._sprite.sprite.position = self.sprite.position
         elif self.slot == "_helmet" and self.gear.helmet:

--- a/src/gui/guild/equipment.py
+++ b/src/gui/guild/equipment.py
@@ -121,11 +121,11 @@ class EquipSection(arcade.Section):
         self.item_receivers = ReceiverCollection(self.armory)
         self.inventory_grid = InventoryGrid(
             6,
-            6,
+            8,
             Vec2(60, 60),
             self.armory,
             self.gear,
-            bottom_left=Vec2(0, 2 * self.height / 4),
+            bottom_left=Vec2(0,215),
             original_draggable_position=self.get_original_draggable_pos,
         )
         self._register_receivers()

--- a/src/gui/guild/equipment.py
+++ b/src/gui/guild/equipment.py
@@ -172,6 +172,7 @@ class EquipSection(arcade.Section):
             self.armory,
             self.gear,
             bottom_left=Vec2(15, 220),
+            top_left=Vec2(15 , self.get_height() + self.get_position().y - 10)
         )
 
         self.prepare_pins()
@@ -217,7 +218,7 @@ class EquipSection(arcade.Section):
         ] - (Vec2(0, self.get_height()) + self.get_position())
         self.inventory_grid.pin_corner(
             Corner.TOP_LEFT,
-            lambda: Vec2(0, self.get_height()) + self.get_position() + top_left_offset,
+            lambda: Vec2(15, self.get_height() + self.bottom - 10)# + self.get_position() + top_left_offset,
         )
 
     def update_debug_text(self):

--- a/src/gui/guild/equipment.py
+++ b/src/gui/guild/equipment.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from copy import copy
 
 import math
+from copy import copy
 from typing import TYPE_CHECKING, Callable
 
 import arcade
@@ -12,12 +12,13 @@ from src.entities.combat.fighter import Fighter
 from src.entities.gear.equippable_item import EquippableItem
 from src.gui.components.buttons import nav_button
 from src.gui.components.draggables import DraggableCollection
+from src.gui.components.observer import Observer, observe
 from src.gui.components.receivers import InventoryGrid, ItemReceiver, ReceiverCollection
 from src.gui.generic_sections.command_bar import CommandBarSection
 from src.gui.guild.snap_grid import GridLoc, SnapGrid
 from src.textures.pixelated_nine_patch import PixelatedNinePatch
 from src.textures.texture_data import SingleTextureSpecs
-from src.utils.rectangle import Corner
+from src.utils.rectangle import Corner, Rectangle
 
 if TYPE_CHECKING:
     from src.entities.gear.gear import Gear
@@ -52,7 +53,7 @@ class EquipView(arcade.View):
                     text=self.to_be_equipped.owner.name.name_and_title,
                     font_size=24,
                     font_name=WindowData.font,
-                )
+                ),
             ],
         )
 
@@ -88,9 +89,18 @@ class EquipView(arcade.View):
     def on_draw(self):
         self.clear()
 
+    def on_update(self, delta_time: float):
+        self.to_be_equipped.owner.entity_sprite.sprite.update_animation(delta_time)
+
     def on_show_view(self) -> None:
         self.info_pane_section.manager.enable()
         self.command_bar_section.manager.enable()
+
+        self.to_be_equipped.owner.entity_sprite.sprite.set_scale(16)
+        self.to_be_equipped.owner.entity_sprite.sprite.position = (
+            self.window.width * 0.7,
+            self.window.height * 0.8,
+        )
 
     def on_hide_view(self) -> None:
         """Disable the UIManager for this view.
@@ -100,11 +110,42 @@ class EquipView(arcade.View):
         self.command_bar_section.manager.disable()
         self.info_pane_section.manager.disable()
 
+        self.to_be_equipped.owner.entity_sprite.sprite.set_scale(4)
+
         self.clear()
 
     def on_resize(self, width: int, height: int) -> None:
         super().on_resize(width, height)
         pass
+
+
+def sync_item_info(equipment_text: arcade.Text, item: EquippableItem | None) -> None:
+    if item is None:
+        equipment_text.text = "No stats to display."
+        return
+
+    equipment_text.text = item.display_stats()
+
+
+def equipment_hover_text(
+    get_item: Callable[[], EquippableItem | None], position: Vec2
+) -> arcade.Text:
+    observer = observe(
+        get_observed_state=get_item,
+        sync_widget=sync_item_info,
+    )
+
+    hovered_item_info = arcade.Text(
+        text="",
+        start_x=position.x,
+        start_y=position.y,
+        font_name=WindowData.font,
+        font_size=18,
+        anchor_x="center",
+    )
+    sync_item_info(hovered_item_info, get_item())
+
+    return observer.attach(hovered_item_info)
 
 
 class EquipSection(arcade.Section):
@@ -119,7 +160,7 @@ class EquipSection(arcade.Section):
     ):
         super().__init__(left, bottom, width, height, **kwargs)
         self.fighter = fighter
-        
+
         self.gear = fighter.gear
         self.armory = eng.game_state.get_guild().armory
 
@@ -130,13 +171,16 @@ class EquipSection(arcade.Section):
             Vec2(60, 60),
             self.armory,
             self.gear,
-            bottom_left=Vec2(15, 220),
-            original_draggable_position=self.get_original_draggable_pos,
+            bottom_left=Vec2(15, self.height - 300),
         )
 
-        top_left_offset = self.inventory_grid.get_bounds().corners[Corner.TOP_LEFT.value] - (Vec2(0, self.get_height()) + self.get_position())
-        self.inventory_grid.pin_corner(Corner.TOP_LEFT, lambda: Vec2(0, self.get_height()) + self.get_position() + top_left_offset)
-        
+        top_left_offset = self.inventory_grid.get_bounds().corners[
+            Corner.TOP_LEFT.value
+        ] - (Vec2(0, self.get_height()) + self.get_position())
+        self.inventory_grid.pin_corner(
+            Corner.TOP_LEFT,
+            lambda: Vec2(0, self.get_height()) + self.get_position() + top_left_offset,
+        )
         self._register_receivers()
 
         self.draggable_collection = DraggableCollection(self.gear, self.inventory_grid)
@@ -144,7 +188,6 @@ class EquipSection(arcade.Section):
         self.mouse = 0, 0
         self.lmb_pressed = False
 
-        self.draggable = None
         self.original_draggable_position = None
         self.grid_backing = PixelatedNinePatch(
             left=16,
@@ -153,21 +196,31 @@ class EquipSection(arcade.Section):
             top=16,
             texture=SingleTextureSpecs.panel_highlighted.loaded,
         )
-        self.item_receivers.sprites.append(
-            self.fighter.owner.entity_sprite.sprite
+        self.item_receivers.sprites.append(self.fighter.owner.entity_sprite.sprite)
+        self.display_hovered = equipment_hover_text(
+            self.currently_hovered, Vec2(self.width * 0.5, 100)
         )
-    
+
+    def currently_hovered(self) -> EquippableItem | None:
+        item = None
+        if draggable := self.draggable_collection.hand:
+            item = draggable.item
+
+        if draggable := self.draggable_collection.draggable_at_position(
+            Vec2(*self.mouse)
+        ):
+            item = draggable.item
+
+        return item
+
     def get_position(self) -> Vec2:
         return Vec2(self.left, self.bottom)
 
     def get_height(self) -> int:
         return self.height
-    
-    def get_original_draggable_pos(self) -> Vec2:
-        return self.original_draggable_position
 
     def _register_receivers(self):
-        slot_x, slot_y = 900, 650
+        slot_x, slot_y = self.window.width * 0.9, 650
         for slot in ("_weapon", "_helmet", "_body"):
             self.item_receivers.register(
                 slot=slot,
@@ -190,24 +243,24 @@ class EquipSection(arcade.Section):
             self.item_receivers.register_armory(receiver)
 
     def on_draw(self):
-        self.grid_backing.draw_sized(position=(0, 205), size=(450, self.height))
+        self.grid_backing.draw_sized(position=(0, 202), size=(450, self.height - 4))
         self.item_receivers.sprites.draw(pixelated=True)
         self.draggable_collection.sprites.draw(pixelated=True)
+        self.display_hovered.draw()
 
     def on_update(self, dt: float):
-        if self.draggable and self.draggable.is_held:
-            self.draggable.sprite.position = self.mouse
+        self.display_hovered.on_update(...)
+
+        if held := self.draggable_collection.hand:
+            held.sprite.position = self.mouse
 
     def on_mouse_press(self, x: int, y: int, button: int, modifiers: int):
         self.mouse = x, y
         self.lmb_pressed = button == arcade.MOUSE_BUTTON_LEFT
         if self.lmb_pressed:
-            for draggable in self.draggable_collection.draggables:
-                if draggable.is_clicked(self.mouse):
-                    draggable.is_held = True
-                    self.draggable = draggable
-                    self.original_draggable_position = self.draggable.sprite.position
-                    return
+            self.original_draggable_position = (
+                self.draggable_collection.pick_up_at_mouse(self.mouse)
+            )
 
     def _get_receiver_sprite(self, x: int, y: int) -> arcade.Sprite | None:
         """
@@ -219,28 +272,29 @@ class EquipSection(arcade.Section):
                 return sprite
 
     def on_mouse_release(self, x: int, y: int, button: int, modifiers: int):
-        if not self.draggable:
+        if not self.draggable_collection.hand:
             return
+
+        held = self.draggable_collection.hand
 
         self.mouse = x, y
         if self.lmb_pressed and button == arcade.MOUSE_BUTTON_LEFT:
             self.lmb_pressed = False
 
             item_slot_sprite, distance = arcade.get_closest_sprite(
-                self.draggable.sprite, self.item_receivers.sprites
+                held.sprite, self.item_receivers.sprites
             )
 
             successfully_placed = False
-            if arcade.check_for_collision(self.draggable.sprite, item_slot_sprite):
+            if arcade.check_for_collision(held.sprite, item_slot_sprite):
                 successfully_placed = self.item_receivers.put_into_slot_at_sprite(
-                    item_slot_sprite, self.draggable
+                    item_slot_sprite, held
                 )
 
             if not successfully_placed:
-                self.draggable.sprite.position = self.original_draggable_position
+                held.sprite.position = self.original_draggable_position
 
-            self.draggable.is_held = False
-            self.draggable = None
+            self.draggable_collection.drop()
 
     def on_mouse_motion(self, x: int, y: int, dx: int, dy: int):
         self.mouse = x, y
@@ -248,7 +302,8 @@ class EquipSection(arcade.Section):
     def on_key_press(self, symbol: int, modifiers: int):
         if symbol == arcade.key.P:
             breakpoint()
-    
+
     def on_resize(self, width, height):
-        self.height = height - 205
+        self.height = height - self.bottom
         self.inventory_grid.on_resize()
+        self.display_hovered.x = self.window.width / 2

--- a/src/gui/guild/equipment.py
+++ b/src/gui/guild/equipment.py
@@ -222,21 +222,21 @@ class EquipSection(arcade.Section):
     def _register_receivers(self):
         slot_x, slot_y = self.window.width * 0.9, 650
         for slot in ("_weapon", "_helmet", "_body"):
-            self.item_receivers.register(
+            receiver = ItemReceiver(
+                gear=self.gear,
                 slot=slot,
-                receiver=ItemReceiver(
-                    gear=self.gear,
-                    slot=slot,
-                    sprite=arcade.SpriteSolidColor(
-                        width=50,
-                        height=50,
-                        color=arcade.csscolor.AQUAMARINE,
-                        center_x=slot_x,
-                        center_y=slot_y,
-                    ),
-                    inventory_grid=self.inventory_grid,
+                sprite=arcade.SpriteSolidColor(
+                    width=50,
+                    height=50,
+                    color=arcade.csscolor.AQUAMARINE,
+                    center_x=slot_x,
+                    center_y=slot_y,
                 ),
+                inventory_grid=self.inventory_grid,
             )
+
+            self.item_receivers.register(slot=slot, receiver=receiver),
+
             slot_y -= 150
 
         for receiver in self.inventory_grid.build_receivers():
@@ -306,4 +306,6 @@ class EquipSection(arcade.Section):
     def on_resize(self, width, height):
         self.height = height - self.bottom
         self.inventory_grid.on_resize()
+        for _, receiver in self.item_receivers._item_receivers.items():
+            receiver.on_resize()
         self.display_hovered.x = self.window.width / 2

--- a/src/gui/guild/equipment.py
+++ b/src/gui/guild/equipment.py
@@ -237,7 +237,7 @@ class EquipSection(arcade.Section):
 
             self.item_receivers.register(slot=slot, receiver=receiver),
 
-            slot_y -= 150
+            slot_y -= 75
 
         for receiver in self.inventory_grid.build_receivers():
             self.item_receivers.register_armory(receiver)

--- a/src/gui/guild/roster.py
+++ b/src/gui/guild/roster.py
@@ -19,7 +19,7 @@ from src.entities.entity import Entity
 from src.gui.components.buttons import nav_button
 from src.gui.components.layouts import (
     box_containing_horizontal_label_pair,
-    label_with_observer,
+    get_colored_label,
 )
 from src.gui.components.observer import observe
 from src.gui.generic_sections.command_bar import CommandBarSection
@@ -31,7 +31,7 @@ from src.gui.guild.roster_sections import (
 from src.gui.window_data import WindowData
 
 
-def entity_observer_widget(get_entity: Callable[[], Entity | None]):
+def entity_observer_widget(get_entity: Callable[[], Entity | None]) -> UILabel:
     def entity_info_label(ui_label, merc: Entity | None) -> None:
         if merc is None:
             ui_label.text = "No stats to display."
@@ -50,7 +50,7 @@ def entity_observer_widget(get_entity: Callable[[], Entity | None]):
         sync_widget=entity_info_label,
     )
 
-    entity_info = label_with_observer(
+    entity_info = get_colored_label(
         label=f"",
         width=WindowData.width,
         height=50,
@@ -77,8 +77,8 @@ class RecruitmentView(arcade.View):
             name="recruitment_pane_section",
             left=2,
             bottom=342,
-            width=WindowData.width,
-            height=WindowData.height,
+            width=self.window.width,
+            height=self.window.height,
             prevent_dispatch_view={False},
         )
         self.add_section(self.recruitment_pane_section)
@@ -194,8 +194,8 @@ class RosterView(arcade.View):
         self.roster_and_team_pane_section = RosterAndTeamPaneSection(
             left=2,
             bottom=342,
-            width=WindowData.width,
-            height=WindowData.height,
+            width=self.window.width,
+            height=self.window.height,
             prevent_dispatch_view={False},
         )
 

--- a/src/gui/guild/snap_grid.py
+++ b/src/gui/guild/snap_grid.py
@@ -1,8 +1,8 @@
-from typing import Generator, NamedTuple, Self, Callable
+from typing import Callable, Generator, NamedTuple, Self
 
 from pyglet.math import Mat4, Vec2, Vec3, Vec4
 
-from src.utils.rectangle import Rectangle, Corner
+from src.utils.rectangle import Corner, Rectangle
 
 
 class GridLoc(NamedTuple):
@@ -42,15 +42,15 @@ class SnapGrid:
         )
 
         return cls(slot_size, screen_area)
-    
-    def pin_corner(self, corner: Corner,  pin: Callable[[], Vec2]):
+
+    def pin_corner(self, corner: Corner, pin: Callable[[], Vec2]):
         self._pin = pin
         self._corner = corner
 
     def on_resize(self):
         if not self._corner or not self._pin:
             return
-        
+
         self.bounds = self.bounds.with_corner_at(self._corner, self._pin())
 
     def translation(self) -> Vec2:

--- a/src/gui/guild/snap_grid.py
+++ b/src/gui/guild/snap_grid.py
@@ -73,7 +73,7 @@ class SnapGrid:
     def snap_to_grid(self, screen_pos: Vec2) -> Vec2 | None:
         if not self.in_screen_area(screen_pos):
             return
-
+        
         grid_vec = self.to_grid(screen_pos)
         snapped = GridLoc.snap(grid_vec)
 

--- a/src/gui/guild/snap_grid.py
+++ b/src/gui/guild/snap_grid.py
@@ -30,7 +30,7 @@ class SnapGrid:
 
     @classmethod
     def from_grid_dimensions(
-        cls, w: int, h: int, slot_size: Vec2, bottom_left: Vec2
+        cls, w: int, h: int, slot_size: Vec2, bottom_left: Vec2, top_left: Vec2
     ) -> Self:
         on_screen_dims = Vec2(
             x=w * slot_size.x,
@@ -38,7 +38,7 @@ class SnapGrid:
         )
 
         screen_area = Rectangle.from_limits(
-            min_v=bottom_left, max_v=bottom_left + on_screen_dims
+            min_v=Vec2(top_left.x, top_left.y - on_screen_dims.y), max_v=Vec2(top_left.x + on_screen_dims.x, top_left.y)
         )
 
         return cls(slot_size, screen_area)

--- a/src/gui/simple_sprite_config.py
+++ b/src/gui/simple_sprite_config.py
@@ -4,6 +4,7 @@ import random
 from typing import TYPE_CHECKING, NamedTuple, Sequence
 
 from arcade import Texture
+
 from src.entities.gear.base_gear_names import BaseWeaponNames
 
 if TYPE_CHECKING:

--- a/src/gui/simple_sprite_config.py
+++ b/src/gui/simple_sprite_config.py
@@ -4,6 +4,7 @@ import random
 from typing import TYPE_CHECKING, NamedTuple, Sequence
 
 from arcade import Texture
+from src.entities.gear.base_gear_names import BaseWeaponNames
 
 if TYPE_CHECKING:
     from src.entities.gear.equippable_item import EquippableItem
@@ -12,32 +13,34 @@ from src.textures.texture_data import SpriteSheetSpecs
 
 
 class SimpleSpriteConfig(NamedTuple):
-    tex_idx: Sequence[int]
+    tex_idx: int
 
     @property
     def texture(self) -> Texture:
         return SpriteSheetSpecs.icons.load_one(self.tex_idx)
 
 
-def choose_item_texture(item: EquippableItem):
+def choose_item_texture(item: EquippableItem) -> Texture:
     match item._slot:
         case "_weapon":
-            if item._name == "sword":
+            if item._name == BaseWeaponNames.SWORD:
                 tx = random.choice(SWORDS)
-            if item._name == "bow":
+            if item._name == BaseWeaponNames.BOW:
                 tx = random.choice(BOWS)
-            if item._name == "grimoire":
+            if item._name == BaseWeaponNames.STAVE:
                 tx = random.choice(STAVES)
 
         case "_helmet":
-            tx = ARMOUR
+            tx = HELMET
         case "_body":
             tx = ARMOUR
 
     return tx.texture
 
 
-ARMOUR = SimpleSpriteConfig(18)
+ARMOUR = SimpleSpriteConfig(84)
+
+HELMET = SimpleSpriteConfig(85)
 
 SWORDS = (
     SimpleSpriteConfig(58),

--- a/src/gui/simple_sprite_config.py
+++ b/src/gui/simple_sprite_config.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, NamedTuple, Sequence
+
+from arcade import Texture
+
+if TYPE_CHECKING:
+    from src.entities.gear.equippable_item import EquippableItem
+
+from src.textures.texture_data import SpriteSheetSpecs
+
+
+class SimpleSpriteConfig(NamedTuple):
+    tex_idx: Sequence[int]
+
+    @property
+    def texture(self) -> Texture:
+        return SpriteSheetSpecs.icons.load_one(self.tex_idx)
+
+
+def choose_item_texture(item: EquippableItem):
+    match item._slot:
+        case "_weapon":
+            if item._name == "sword":
+                tx = random.choice(SWORDS)
+            if item._name == "bow":
+                tx = random.choice(BOWS)
+            if item._name == "grimoire":
+                tx = random.choice(STAVES)
+
+        case "_helmet":
+            tx = ARMOUR
+        case "_body":
+            tx = ARMOUR
+
+    return tx.texture
+
+
+ARMOUR = SimpleSpriteConfig(18)
+
+SWORDS = (
+    SimpleSpriteConfig(58),
+    SimpleSpriteConfig(68),
+    SimpleSpriteConfig(78),
+    SimpleSpriteConfig(88),
+    SimpleSpriteConfig(98),
+    SimpleSpriteConfig(108),
+)
+
+STAVES = (
+    SimpleSpriteConfig(57),
+    SimpleSpriteConfig(67),
+    SimpleSpriteConfig(77),
+    SimpleSpriteConfig(87),
+    SimpleSpriteConfig(97),
+    SimpleSpriteConfig(107),
+)
+
+BOWS = (
+    SimpleSpriteConfig(59),
+    SimpleSpriteConfig(69),
+    SimpleSpriteConfig(79),
+    SimpleSpriteConfig(89),
+    SimpleSpriteConfig(99),
+    SimpleSpriteConfig(109),
+)

--- a/src/gui/window_data.py
+++ b/src/gui/window_data.py
@@ -11,8 +11,8 @@ def _cross_platform_name(name: str) -> str:
 
 
 class WindowData:
-    width = 1080
-    height = 720
-    scale = (width / 1080, height / 720)
+    width = 1600
+    height = 900
+    scale = (width / 1600, height / 900)
     window_icon = pyglet.image.load("./assets/icon.png")
     font = _cross_platform_name("Alagard")

--- a/src/textures/texture_data.py
+++ b/src/textures/texture_data.py
@@ -112,7 +112,7 @@ class SpriteSheetSpecs:
                 "sprite_height": 8,
                 "sprite_width": 8,
                 "columns": 10,
-                "count": 86,
+                "count": 110,
                 "margin": 0,
             }
         ),

--- a/src/utils/rectangle.py
+++ b/src/utils/rectangle.py
@@ -1,12 +1,13 @@
 import operator
-from typing import NamedTuple, Self
 from enum import Enum
+from typing import NamedTuple, Self
 
 from arcade.camera import FourFloatTuple, FourIntTuple
 from pyglet.math import Vec2
 
 Real = int | float
 FourNumbers = tuple[Real, Real, Real, Real]
+
 
 class Corner(Enum):
     BOTTOM_LEFT = 0
@@ -277,10 +278,10 @@ class Rectangle(NamedTuple):
 
         """
         return self.from_limits(self.min + displacement, self.max + displacement)
-    
+
     def with_corner_at(self, corner: Corner, position: Vec2) -> Self:
         """
-        This will return a rectangle which is a translation of this instance and whose specified corner 
+        This will return a rectangle which is a translation of this instance and whose specified corner
         will be at the position supplied.
 
         Args:

--- a/src/utils/rectangle.py
+++ b/src/utils/rectangle.py
@@ -1,11 +1,18 @@
 import operator
-from typing import Any, NamedTuple, Self, Tuple
+from typing import NamedTuple, Self
+from enum import Enum
 
 from arcade.camera import FourFloatTuple, FourIntTuple
 from pyglet.math import Vec2
 
 Real = int | float
 FourNumbers = tuple[Real, Real, Real, Real]
+
+class Corner(Enum):
+    BOTTOM_LEFT = 0
+    TOP_LEFT = 1
+    TOP_RIGHT = 2
+    BOTTOM_RIGHT = 3
 
 
 class Rectangle(NamedTuple):
@@ -270,6 +277,22 @@ class Rectangle(NamedTuple):
 
         """
         return self.from_limits(self.min + displacement, self.max + displacement)
+    
+    def with_corner_at(self, corner: Corner, position: Vec2) -> Self:
+        """
+        This will return a rectangle which is a translation of this instance and whose specified corner 
+        will be at the position supplied.
+
+        Args:
+            corner: The corner whose position is being set.
+            position: Where the returned rectangle's target corner will be located.
+
+        Returns: A new Rectangle instance
+        """
+        old_corner = self.corners[corner.value]
+        translation = position - old_corner
+
+        return self.translate(translation)
 
     def __contains__(self, other):
         if isinstance(other, Rectangle):


### PR DESCRIPTION
- Split SpriteAttribute into Simple/AnimatedSpriteAttribute. Both have an owner, Simple only has a single texture.
- Set up texture configs for item icons.
- Fixed storage losing track of items if they were moved around in the inventory.